### PR TITLE
Add dealer reputation system with upgradeable scalpels

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,23 @@ Missions illégales de prélèvement d'organes sur des PNJ aléatoires, avec ven
 3. Ouvre `config.lua` et :
    - remplace `Config.DiscordWebhook` avec ton URL.
    - vérifie `Config.UseBlackMoney` (true = black_money, false = cash).
+4. Importe le fichier `sql/organ_stats.sql` pour créer la table de suivi de réputation.
 
 ## Items (ox_inventory)
 Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fichier équivalent) :
 
 ```lua
 -- OUTLAW ORGAN HARVEST ITEMS
-['scalpel'] = { label = 'Scalpel', weight = 50, stack = true, close = true, description = 'Instrument chirurgical' },
-['rein']    = { label = 'Rein', weight = 200, stack = true, close = true },
-['crane']   = { label = 'Crâne', weight = 300, stack = true, close = true },
-['pied']    = { label = 'Pied', weight = 250, stack = true, close = true },
-['yeux']    = { label = 'Yeux', weight = 80, stack = true, close = true },
-['organe']  = { label = 'Organe', weight = 150, stack = true, close = true },
-['coeur']   = { label = 'Cœur', weight = 120, stack = true, close = true },
-['os']      = { label = 'Os', weight = 60, stack = true, close = true },
+['scalpel']       = { label = 'Scalpel', weight = 50, stack = true, close = true, description = 'Instrument chirurgical' },
+['scalpel_pro']   = { label = 'Scalpel pro', weight = 55, stack = true, close = true, description = 'Affûté pour un travail propre' },
+['scalpel_honed'] = { label = 'Scalpel affûté', weight = 55, stack = true, close = true, description = 'Réservé aux vétérans du marché noir' },
+['rein']          = { label = 'Rein', weight = 200, stack = true, close = true },
+['crane']         = { label = 'Crâne', weight = 300, stack = true, close = true },
+['pied']          = { label = 'Pied', weight = 250, stack = true, close = true },
+['yeux']          = { label = 'Yeux', weight = 80, stack = true, close = true },
+['organe']        = { label = 'Organe', weight = 150, stack = true, close = true },
+['coeur']         = { label = 'Cœur', weight = 120, stack = true, close = true },
+['os']            = { label = 'Os', weight = 60, stack = true, close = true },
 ```
 
 > ⚠️ Les items **doivent exister** côté `ox_inventory`, sinon rien ne sera ajouté/retiré.
@@ -49,3 +52,4 @@ Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fich
 - Tu peux déplacer les PNJ (Mission/Dealer) et les zones dans `config.lua`.
 - Ajuste les **prix** dans `Config.ItemDetails`.
 - Le script envoie des **logs** sur Discord si `Config.DiscordWebhook` est rempli.
+- Les PNJ dealers gèrent désormais la **réputation** du vendeur, la progression des contrats et l'accès aux **scalpels améliorés** via un menu ox_lib.

--- a/config.lua
+++ b/config.lua
@@ -32,13 +32,13 @@ Config.SpawnZones = {
 }
 
 Config.ItemDetails = {
-    rein  = { price = 400, limit = 1 },
-    crane = { price = 150, limit = 1 },
-    pied  = { price = 200, limit = 1 },
-    yeux  = { price = 250, limit = 2 },
-    organe= { price = 350, limit = 1 },
-    coeur = { price = 800, limit = 1 },
-    os    = { price = 20,  limit = 4 },
+    rein  = { label = 'Rein',    price = 400, limit = 1 },
+    crane = { label = 'Crâne',   price = 150, limit = 1 },
+    pied  = { label = 'Pied',    price = 200, limit = 1 },
+    yeux  = { label = 'Yeux',    price = 250, limit = 2 },
+    organe= { label = 'Organe',  price = 350, limit = 1 },
+    coeur = { label = 'Cœur',    price = 800, limit = 1 },
+    os    = { label = 'Os',      price = 20,  limit = 4 },
 }
 
 Config.MissionCooldown = 300
@@ -49,6 +49,51 @@ Config.Scalpel = {
     kit   = 'surgery_kit',
     proQualityBonus = 10,
     kitExtraSeconds  = 180
+}
+
+Config.ScalpelTiers = {
+    basic = {
+        item = 'scalpel',
+        label = 'Scalpel (basique)',
+        price = 250,
+        reputation = 0,
+        requires = {},
+        qualityBonus = 0,
+        secondHarvestChance = 0.0,
+        description = 'Outil standard fourni sans condition.'
+    },
+    pro = {
+        item = 'scalpel_pro',
+        label = 'Scalpel (pro)',
+        price = 1500,
+        reputation = 35,
+        requires = { rein = 8, yeux = 4 },
+        qualityBonus = 10,
+        secondHarvestChance = Config.SecondHarvestChance or 0.17,
+        description = 'Améliore la qualité des prélèvements et ouvre la voie aux doubles récoltes.'
+    },
+    honed = {
+        item = 'scalpel_honed',
+        label = 'Scalpel affûté',
+        price = 3200,
+        reputation = 120,
+        requires = { rein = 20, crane = 10, coeur = 3 },
+        qualityBonus = 18,
+        secondHarvestChance = 0.28,
+        description = 'Version affûtée du scalpel, réservée aux vétérans au sang-froid.'
+    }
+}
+
+Config.Reputation = {
+    Max = 500,
+    PriceBonusPerPoint = 0.0025, -- +0.25% par point
+    MaxPriceBonus = 0.6,         -- Bonus max de +60%
+    SaleQualityWeight = 0.08,    -- Influence de la qualité sur le gain de réput.
+    SaleMinQuality = 40,         -- Qualité minimale pour générer de la réput.
+    ContractBonus = 6,           -- Bonus fixe par contrat terminé
+    RareOrders = {
+        coeur = 110
+    }
 }
 
 -- Base TTL (seconds) before organ rots (without any bonus)

--- a/sql/organ_stats.sql
+++ b/sql/organ_stats.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `outlaw_organ_stats` (
+  `identifier` VARCHAR(64) NOT NULL,
+  `reputation` INT NOT NULL DEFAULT 0,
+  `contracts` INT NOT NULL DEFAULT 0,
+  `deliveries` LONGTEXT DEFAULT NULL,
+  `unlocks` LONGTEXT DEFAULT NULL,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`identifier`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
## Summary
- add persistent vendor reputation tracking with configurable price bonuses and rare organ unlocks
- replace dealer interactions with an ox_lib context menu that exposes stats, deliveries and scalpel upgrades
- introduce upgradeable scalpel tiers, new honed scalpel item and SQL schema for tracking deliveries/contracts

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e285b480788328a82aae688994416c