### PR TITLE
Add Outlaw-styled dealer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fich
 - Chaque type de contrat (os, pieds, crânes, etc.) possède des prérequis en **livraisons cumulées** et en **réputation**.
 - Tant qu'un contrat n'est pas débloqué, l'organe correspondant ne peut pas apparaître dans les récoltes aléatoires.
 - Une fois un palier atteint, tu peux acheter un **contrat ciblé** (ex: « Commande rénale ») qui force l'organe obtenu et impose un délai (configurable) pour réussir.
+- Après prélèvement de l’organe demandé par un contrat ciblé, utilise l’action **Terminer mission** (depuis le dealer ou le tableau) pour valider la commande sans fermer l’interface.
 - Le menu affiche :
   - ta progression sur chaque contrat (barres et pourcentages) ;
   - les bonus de réputation accordés par les contrats spéciaux ;

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fich
   - Les commandes rares et leur statut.
 - Certaines améliorations (ex: **Scalpel Élite**) nécessitent un certain niveau de réputation **et** des quantités livrées spécifiques pour être accessibles.
 
+## Tableau des missions
+- Parle au donneur de missions pour ouvrir l'interface **Outlaw** dédiée (même style que le dealer).
+- Chaque type de contrat (os, pieds, crânes, etc.) possède des prérequis en **livraisons cumulées** et en **réputation**.
+- Tant qu'un contrat n'est pas débloqué, l'organe correspondant ne peut pas apparaître dans les récoltes aléatoires.
+- Une fois un palier atteint, tu peux acheter un **contrat ciblé** (ex: « Commande rénale ») qui force l'organe obtenu et impose un délai (configurable) pour réussir.
+- Le menu affiche :
+  - ta progression sur chaque contrat (barres et pourcentages) ;
+  - les bonus de réputation accordés par les contrats spéciaux ;
+  - la composition actuelle de la **pool** d'organes disponibles en mission libre.
+- Ajuste les paliers, coûts, délais et bonus dans `Config.MissionBoard` (section `Config.MissionBoard.Contracts`).
+
 ## Commande utilitaire
 - `/organreset` : réinitialise ta mission et le cooldown (utile en test).
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Missions illégales de prélèvement d'organes sur des PNJ aléatoires, avec ven
 ## Items (ox_inventory)
 Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fichier équivalent) :
 
+> 📄 Un fichier prêt à copier est disponible dans [`item_data/ox_inventory.lua`](item_data/ox_inventory.lua).
+
 ```lua
 -- OUTLAW ORGAN HARVEST ITEMS
 ['scalpel'] = { label = 'Scalpel', weight = 50, stack = true, close = true, description = 'Instrument chirurgical' },

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fich
 ```lua
 -- OUTLAW ORGAN HARVEST ITEMS
 ['scalpel'] = { label = 'Scalpel', weight = 50, stack = true, close = true, description = 'Instrument chirurgical' },
+['scalpel_pro'] = { label = 'Scalpel Pro', weight = 50, stack = true, close = true, description = 'Affûtage renforcé' },
+['scalpel_elite'] = { label = 'Scalpel Élite', weight = 50, stack = true, close = true, description = 'Lame personnalisée et équilibrée' },
+['surgery_kit'] = { label = 'Kit chirurgical', weight = 150, stack = true, close = true, description = 'Stérilisation et outils à usage unique' },
 ['rein']    = { label = 'Rein', weight = 200, stack = true, close = true },
 ['crane']   = { label = 'Crâne', weight = 300, stack = true, close = true },
 ['pied']    = { label = 'Pied', weight = 250, stack = true, close = true },
@@ -39,8 +42,19 @@ Tu dois déclarer les items suivants dans `ox_inventory/data/items.lua` (ou fich
 ## Fonctionnement
 - Parle au **PNJ Mission** pour recevoir une **cible** (ped aléatoire) dans une zone.
 - Approche la cible et utilise l’option **Prélever un organe** (besoin d’un **scalpel**).
-- Une fois l’organe obtenu, rends-toi au **Dealer** pour **vendre** tes organes.
+- Une fois l’organe obtenu, rends-toi au **Dealer** pour **vendre** tes organes ou accéder au nouveau **menu réputation**.
+- Les ventes de **qualité** améliorent ta réputation et débloquent des commandes rares (comme le **cœur**) et des bonus sur le prix de base.
+- Utilise le menu du dealer pour acheter du matériel, suivre tes statistiques et **améliorer ton scalpel** si tu as les livraisons requises.
 - **Cooldown** configurable entre deux missions (par joueur).
+
+## Réputation du dealer
+- Chaque organe vendu octroie des points de réputation en fonction de la qualité et du type de pièce.
+- Des **paliers** augmentent automatiquement le multiplicateur de prix et débloquent de nouveaux organes dans la rotation des missions.
+- Le menu du dealer affiche :
+  - Les contrats terminés, la qualité moyenne et la meilleure qualité livrée.
+  - Le cumul de chaque organe vendu et les seuils de déblocage.
+  - Les commandes rares et leur statut.
+- Certaines améliorations (ex: **Scalpel Élite**) nécessitent un certain niveau de réputation **et** des quantités livrées spécifiques pour être accessibles.
 
 ## Commande utilitaire
 - `/organreset` : réinitialise ta mission et le cooldown (utile en test).

--- a/client/main.lua
+++ b/client/main.lua
@@ -160,6 +160,16 @@ RegisterNUICallback('dealer_upgrade', function(data, cb)
     cb({})
 end)
 
+RegisterNUICallback('dealer_open_missions', function(_, cb)
+    TriggerServerEvent('outlaw_organ:requestMissionMenu')
+    cb({})
+end)
+
+RegisterNUICallback('dealer_finish_mission', function(_, cb)
+    TriggerServerEvent('outlaw_organ:completeSpecialMission')
+    cb({})
+end)
+
 RegisterNUICallback('mission_close', function(_, cb)
     closeMissionUi()
     cb({})
@@ -167,6 +177,11 @@ end)
 
 RegisterNUICallback('mission_start', function(data, cb)
     TriggerServerEvent('outlaw_organ:startMission', data or {})
+    cb({})
+end)
+
+RegisterNUICallback('mission_finish', function(_, cb)
+    TriggerServerEvent('outlaw_organ:completeSpecialMission')
     cb({})
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -185,6 +185,11 @@ RegisterNUICallback('mission_finish', function(_, cb)
     cb({})
 end)
 
+RegisterNUICallback('mission_open_dealer', function(_, cb)
+    TriggerServerEvent('outlaw_organ:requestDealerMenu')
+    cb({})
+end)
+
 AddEventHandler('onResourceStop', function(resource)
     if resource ~= GetCurrentResourceName() then return end
     closeDealerUi()

--- a/client/main.lua
+++ b/client/main.lua
@@ -89,6 +89,13 @@ RegisterNetEvent('outlaw_organ:openDealerMenu', function(data)
     openDealerUi(data)
 end)
 
+RegisterNetEvent('outlaw_organ:updateDealerMenu', function(data)
+    if not data then return end
+    if dealerUiOpen then
+        SendNUIMessage({ action = 'updateDealer', payload = data })
+    end
+end)
+
 RegisterNUICallback('dealer_close', function(_, cb)
     closeDealerUi()
     cb({})

--- a/config.lua
+++ b/config.lua
@@ -32,23 +32,52 @@ Config.SpawnZones = {
 }
 
 Config.ItemDetails = {
-    rein  = { price = 400, limit = 1 },
-    crane = { price = 150, limit = 1 },
-    pied  = { price = 200, limit = 1 },
-    yeux  = { price = 250, limit = 2 },
-    organe= { price = 350, limit = 1 },
-    coeur = { price = 800, limit = 1 },
-    os    = { price = 20,  limit = 4 },
+    rein  = { label = 'Rein',   price = 400, limit = 1, rep = 8,  unlockReputation = 0 },
+    crane = { label = 'Crâne',  price = 150, limit = 1, rep = 4,  unlockReputation = 0 },
+    pied  = { label = 'Pied',   price = 200, limit = 1, rep = 5,  unlockReputation = 0 },
+    yeux  = { label = 'Yeux',   price = 250, limit = 2, rep = 6,  unlockReputation = 120 },
+    organe= { label = 'Organe', price = 350, limit = 1, rep = 7,  unlockReputation = 0 },
+    coeur = { label = 'Cœur',   price = 900, limit = 1, rep = 18, unlockReputation = 320 },
+    os    = { label = 'Os',     price = 20,  limit = 4, rep = 1,  unlockReputation = 0 },
+}
+
+Config.Reputation = {
+    Max = 2000,
+    BaseGainPerItem = 3,
+    QualityWeight = 0.25,
+    ContractBonus = 25,
+    Tiers = {
+        { name = 'Recrue',        reputation = 0,   multiplier = 1.0 },
+        { name = 'Complice',      reputation = 120, multiplier = 1.1 },
+        { name = 'Dissecteur',    reputation = 320, multiplier = 1.25 },
+        { name = 'Chirurgien',    reputation = 620, multiplier = 1.4 },
+        { name = 'Légende',       reputation = 1100, multiplier = 1.6 },
+    },
+    RareOrders = {
+        coeur = { reputation = 320 },
+    }
 }
 
 Config.MissionCooldown = 300
 
 Config.Scalpel = {
-    basic = 'scalpel',
-    pro   = 'scalpel_pro',
     kit   = 'surgery_kit',
-    proQualityBonus = 10,
-    kitExtraSeconds  = 180
+    kitExtraSeconds  = 180,
+    variants = {
+        basic = { item = 'scalpel',      label = 'Scalpel (basique)', bonusQuality = 0,  buyPrice = 250,  reputation = 0,   secondHarvestChance = 0.0 },
+        pro   = { item = 'scalpel_pro',  label = 'Scalpel (pro)',     bonusQuality = 10, buyPrice = 1500, reputation = 120, secondHarvestChance = 0.2 },
+        elite = { item = 'scalpel_elite',label = 'Scalpel (élite)',   bonusQuality = 18, buyPrice = 0,    reputation = 380, secondHarvestChance = 0.35 },
+    },
+    upgrades = {
+        elite = {
+            id = 'elite',
+            from = 'pro',
+            to = 'elite',
+            price = 5500,
+            reputation = 380,
+            deliveries = { rein = 20, yeux = 12, coeur = 3 },
+        }
+    }
 }
 
 -- Base TTL (seconds) before organ rots (without any bonus)

--- a/config.lua
+++ b/config.lua
@@ -66,14 +66,14 @@ Config.Scalpel = {
     variants = {
         basic = { item = 'scalpel',      label = 'Scalpel (basique)', bonusQuality = 0,  buyPrice = 250,  reputation = 0,   secondHarvestChance = 0.0 },
         pro   = { item = 'scalpel_pro',  label = 'Scalpel (pro)',     bonusQuality = 10, buyPrice = 1500, reputation = 120, secondHarvestChance = 0.2 },
-        elite = { item = 'scalpel_elite',label = 'Scalpel (élite)',   bonusQuality = 18, buyPrice = 0,    reputation = 380, secondHarvestChance = 0.35 },
+        elite = { item = 'scalpel_elite',label = 'Scalpel (élite)',   bonusQuality = 18, buyPrice = 5500, reputation = 380, secondHarvestChance = 0.35 },
     },
     upgrades = {
         elite = {
             id = 'elite',
             from = 'pro',
             to = 'elite',
-            price = 5500,
+            price = 0,
             reputation = 380,
             deliveries = { rein = 20, yeux = 12, coeur = 3 },
         }

--- a/config.lua
+++ b/config.lua
@@ -60,6 +60,90 @@ Config.Reputation = {
 
 Config.MissionCooldown = 300
 
+-- Progression des contrats de mission (débloque la pool d'organes et les missions ciblées)
+Config.MissionBoard = {
+    DefaultTimeLimit = 15 * 60,
+    Contracts = {
+        os = {
+            label = 'Commande osseuse',
+            item = 'os',
+            order = 1,
+            description = 'Ramasser des os frais pour alimenter la chaîne clandestine.',
+            timeLimit = 10 * 60,
+            fee = 0,
+            reputation = 0,
+            deliveries = {},
+            bonusReputation = 6
+        },
+        pied = {
+            label = 'Commande pédestre',
+            item = 'pied',
+            order = 2,
+            description = 'Fournir des pieds propres pour les trafiquants.',
+            timeLimit = 12 * 60,
+            fee = 250,
+            reputation = 80,
+            deliveries = { os = 50 },
+            bonusReputation = 10
+        },
+        crane = {
+            label = 'Commande crânienne',
+            item = 'crane',
+            order = 3,
+            description = 'Collecter des boîtes crâniennes intactes.',
+            timeLimit = 12 * 60,
+            fee = 350,
+            reputation = 120,
+            deliveries = { os = 75, pied = 40 },
+            bonusReputation = 12
+        },
+        yeux = {
+            label = 'Commande oculaire',
+            item = 'yeux',
+            order = 4,
+            description = 'Livrer des yeux sans tache ni éraflure.',
+            timeLimit = 14 * 60,
+            fee = 450,
+            reputation = 180,
+            deliveries = { os = 110, pied = 65, crane = 30 },
+            bonusReputation = 14
+        },
+        organe = {
+            label = 'Commande viscérale',
+            item = 'organe',
+            order = 5,
+            description = 'Acheminer des organes internes utilisables.',
+            timeLimit = 14 * 60,
+            fee = 550,
+            reputation = 220,
+            deliveries = { os = 140, pied = 85, crane = 45, yeux = 25 },
+            bonusReputation = 16
+        },
+        rein = {
+            label = 'Commande rénale',
+            item = 'rein',
+            order = 6,
+            description = 'Prélever un rein prêt pour la transplantation.',
+            timeLimit = 15 * 60,
+            fee = 700,
+            reputation = 320,
+            deliveries = { os = 180, pied = 120, crane = 70, yeux = 40, organe = 20 },
+            bonusReputation = 20
+        },
+        coeur = {
+            label = 'Commande cardiaque',
+            item = 'coeur',
+            order = 7,
+            description = 'Assurer un cœur vibrant livré dans les temps.',
+            timeLimit = 16 * 60,
+            fee = 900,
+            reputation = 420,
+            deliveries = { os = 220, pied = 160, crane = 110, yeux = 60, rein = 30 },
+            bonusReputation = 25
+        }
+    }
+}
+
 Config.Scalpel = {
     kit   = 'surgery_kit',
     kitExtraSeconds  = 180,

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,6 +7,14 @@ author 'OutlawTwinCoder'
 description 'Illegal organ harvest missions with decay/quality, multi-harvest, heat, witnesses & dispatch + inventory tooltip/inspect + live durability bar'
 version '1.3.0'
 
+ui_page 'ui/index.html'
+
+files {
+    'ui/index.html',
+    'ui/style.css',
+    'ui/app.js'
+}
+
 shared_scripts {
     '@ox_lib/init.lua',
     'config.lua'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,7 +12,8 @@ ui_page 'ui/index.html'
 files {
     'ui/index.html',
     'ui/style.css',
-    'ui/app.js'
+    'ui/app.js',
+    'ui/mission.js'
 }
 
 shared_scripts {

--- a/item_data/ox_inventory.lua
+++ b/item_data/ox_inventory.lua
@@ -1,99 +1,18 @@
--- Items à copier dans ox_inventory/data/items.lua pour Outlaw_OrganHarvest
 return {
-    -- Scalpels et consommables
-    ['scalpel'] = {
-        label = 'Scalpel',
-        weight = 50,
-        stack = true,
-        close = true,
-        description = 'Instrument chirurgical basique'
-    },
-    ['scalpel_pro'] = {
-        label = 'Scalpel Pro',
-        weight = 50,
-        stack = true,
-        close = true,
-        description = 'Affûtage renforcé pour de meilleures coupes'
-    },
-    ['scalpel_elite'] = {
-        label = 'Scalpel Élite',
-        weight = 50,
-        stack = true,
-        close = true,
-        description = 'Lame modifiée, équilibre parfait'
-    },
-    ['surgery_kit'] = {
-        label = 'Kit chirurgical',
-        weight = 150,
-        stack = true,
-        close = true,
-        description = 'Stérilisation et outils jetables'
-    },
+    -- OUTLAW ORGAN TOOLS
+    ['scalpel'] = { label='Scalpel', weight=50, stack=true, close=true },
+    ['scalpel_pro'] = { label='Scalpel Pro', weight=50, stack=true, close=true, description='+10% qualité, 2e prélèvement possible' },
+    ['surgery_kit'] = { label='Kit chirurgical', weight=200, stack=true, close=true, description='+TTL (consommable)' },
+    ['cooler'] = { label='Glacière', weight=600, stack=false, close=true },
+    ['icepack'] = { label='Pack de glace', weight=100, stack=true, close=true },
+    ['gants'] = { label='Gants', weight=10, stack=true, close=true },
 
-    -- Outils de conservation / sécurité
-    ['cooler'] = {
-        label = 'Glacière médicale',
-        weight = 700,
-        stack = false,
-        close = true,
-        description = 'Maintient les organes au frais plus longtemps'
-    },
-    ['icepack'] = {
-        label = 'Pack de glace',
-        weight = 150,
-        stack = true,
-        close = true,
-        description = 'Bonus de conservation ponctuel'
-    },
-    ['gants'] = {
-        label = 'Gants stériles',
-        weight = 10,
-        stack = true,
-        close = true,
-        description = 'Réduit les risques d\'infection'
-    },
-
-    -- Organes / pièces récoltées
-    ['rein'] = {
-        label = 'Rein',
-        weight = 200,
-        stack = true,
-        close = true
-    },
-    ['crane'] = {
-        label = 'Crâne',
-        weight = 300,
-        stack = true,
-        close = true
-    },
-    ['pied'] = {
-        label = 'Pied',
-        weight = 250,
-        stack = true,
-        close = true
-    },
-    ['yeux'] = {
-        label = 'Yeux',
-        weight = 80,
-        stack = true,
-        close = true
-    },
-    ['organe'] = {
-        label = 'Organe',
-        weight = 150,
-        stack = true,
-        close = true
-    },
-    ['coeur'] = {
-        label = 'Cœur',
-        weight = 120,
-        stack = true,
-        close = true
-    },
-    ['os'] = {
-        label = 'Os',
-        weight = 60,
-        stack = true,
-        close = true
-    }
+    -- ORGANS
+    ['rein'] = { label='Rein', weight=200, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
+    ['crane'] = { label='Crâne', weight=300, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
+    ['pied'] = { label='Pied', weight=250, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
+    ['yeux'] = { label='Yeux', weight=80, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
+    ['organe'] = { label='Organe', weight=150, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
+    ['coeur'] = { label='Cœur', weight=120, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
+    ['os'] = { label='Os', weight=60, stack=true, close=true, client={ export='Outlaw_OrganHarvest.inspectOrgan' } },
 }

--- a/item_data/ox_inventory.lua
+++ b/item_data/ox_inventory.lua
@@ -2,6 +2,7 @@ return {
     -- OUTLAW ORGAN TOOLS
     ['scalpel'] = { label='Scalpel', weight=50, stack=true, close=true },
     ['scalpel_pro'] = { label='Scalpel Pro', weight=50, stack=true, close=true, description='+10% qualité, 2e prélèvement possible' },
+    ['scalpel_elite'] = { label='Scalpel Élite', weight=50, stack=true, close=true, description='+18% qualité, chance double améliorée' },
     ['surgery_kit'] = { label='Kit chirurgical', weight=200, stack=true, close=true, description='+TTL (consommable)' },
     ['cooler'] = { label='Glacière', weight=600, stack=false, close=true },
     ['icepack'] = { label='Pack de glace', weight=100, stack=true, close=true },

--- a/item_data/ox_inventory.lua
+++ b/item_data/ox_inventory.lua
@@ -1,0 +1,99 @@
+-- Items à copier dans ox_inventory/data/items.lua pour Outlaw_OrganHarvest
+return {
+    -- Scalpels et consommables
+    ['scalpel'] = {
+        label = 'Scalpel',
+        weight = 50,
+        stack = true,
+        close = true,
+        description = 'Instrument chirurgical basique'
+    },
+    ['scalpel_pro'] = {
+        label = 'Scalpel Pro',
+        weight = 50,
+        stack = true,
+        close = true,
+        description = 'Affûtage renforcé pour de meilleures coupes'
+    },
+    ['scalpel_elite'] = {
+        label = 'Scalpel Élite',
+        weight = 50,
+        stack = true,
+        close = true,
+        description = 'Lame modifiée, équilibre parfait'
+    },
+    ['surgery_kit'] = {
+        label = 'Kit chirurgical',
+        weight = 150,
+        stack = true,
+        close = true,
+        description = 'Stérilisation et outils jetables'
+    },
+
+    -- Outils de conservation / sécurité
+    ['cooler'] = {
+        label = 'Glacière médicale',
+        weight = 700,
+        stack = false,
+        close = true,
+        description = 'Maintient les organes au frais plus longtemps'
+    },
+    ['icepack'] = {
+        label = 'Pack de glace',
+        weight = 150,
+        stack = true,
+        close = true,
+        description = 'Bonus de conservation ponctuel'
+    },
+    ['gants'] = {
+        label = 'Gants stériles',
+        weight = 10,
+        stack = true,
+        close = true,
+        description = 'Réduit les risques d\'infection'
+    },
+
+    -- Organes / pièces récoltées
+    ['rein'] = {
+        label = 'Rein',
+        weight = 200,
+        stack = true,
+        close = true
+    },
+    ['crane'] = {
+        label = 'Crâne',
+        weight = 300,
+        stack = true,
+        close = true
+    },
+    ['pied'] = {
+        label = 'Pied',
+        weight = 250,
+        stack = true,
+        close = true
+    },
+    ['yeux'] = {
+        label = 'Yeux',
+        weight = 80,
+        stack = true,
+        close = true
+    },
+    ['organe'] = {
+        label = 'Organe',
+        weight = 150,
+        stack = true,
+        close = true
+    },
+    ['coeur'] = {
+        label = 'Cœur',
+        weight = 120,
+        stack = true,
+        close = true
+    },
+    ['os'] = {
+        label = 'Os',
+        weight = 60,
+        stack = true,
+        close = true
+    }
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,6 +5,12 @@ local heat = {}     -- [src] = { value=0, updatedAt=os.time() }
 local invOpen = {}  -- [src] = true/false
 local statsCache = {} -- [identifier] = stats table
 
+local getMissionEntry
+local evaluateMissionRequirements
+local organUnlockedForPlayer
+local buildMissionSnapshot
+local sendMissionSnapshot
+
 local function now() return os.time() end
 
 local function getIdentifier(src)
@@ -716,12 +722,12 @@ local function getMissionContracts()
     return (Config.MissionBoard and Config.MissionBoard.Contracts) or {}
 end
 
-local function getMissionEntry(id)
+getMissionEntry = function(id)
     local contracts = getMissionContracts()
     return contracts and contracts[id] or nil
 end
 
-local function evaluateMissionRequirements(stats, entry)
+evaluateMissionRequirements = function(stats, entry)
     local reputation = stats and (stats.reputation or 0) or 0
     local deliveries = (stats and stats.deliveries) or {}
     local requirements, reasons = {}, {}
@@ -774,7 +780,7 @@ local function evaluateMissionRequirements(stats, entry)
     return unlocked, requirements, reasons, progress
 end
 
-local function organUnlockedForPlayer(stats, organ)
+organUnlockedForPlayer = function(stats, organ)
     local details = Config.ItemDetails[organ]
     local reputation = stats and (stats.reputation or 0) or 0
     if details and details.unlockReputation and reputation < details.unlockReputation then
@@ -787,7 +793,7 @@ local function organUnlockedForPlayer(stats, organ)
     return true
 end
 
-local function buildMissionSnapshot(src, stats)
+buildMissionSnapshot = function(src, stats)
     stats = stats or select(1, getStats(src))
     if not stats then return nil end
 
@@ -900,7 +906,7 @@ local function buildMissionSnapshot(src, stats)
     }
 end
 
-local function sendMissionSnapshot(src, action, stats)
+sendMissionSnapshot = function(src, action, stats)
     local snapshot = buildMissionSnapshot(src, stats)
     if not snapshot then return end
     TriggerClientEvent(action or 'outlaw_organ:updateMissionMenu', src, snapshot)

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,6 +5,7 @@ local heat = {}     -- [src] = { value=0, updatedAt=os.time() }
 local invOpen = {}  -- [src] = true/false
 local statsCache = {} -- [identifier] = stats table
 
+local getMissionContracts
 local getMissionEntry
 local evaluateMissionRequirements
 local organUnlockedForPlayer
@@ -867,7 +868,7 @@ buildDealerSnapshot = function(src, stats)
     }
 end
 
-local function getMissionContracts()
+getMissionContracts = function()
     return (Config.MissionBoard and Config.MissionBoard.Contracts) or {}
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,8 +3,87 @@ local ESX = exports['es_extended']:getSharedObject()
 local missions = {} -- [src] = { netId=..., coords=vector3, startedAt=os.time(), harvested=0, given={}, canSecond=false, lastDispatchAt=0 }
 local heat = {}     -- [src] = { value=0, updatedAt=os.time() }
 local invOpen = {}  -- [src] = true/false
+local statsCache = {} -- [identifier] = stats table
 
 local function now() return os.time() end
+
+local function getIdentifier(src)
+    local xPlayer = ESX.GetPlayerFromId(src)
+    if not xPlayer then return nil end
+    local identifier = xPlayer.identifier
+    if not identifier and xPlayer.getIdentifier then identifier = xPlayer.getIdentifier() end
+    return identifier
+end
+
+local function clampReputation(value)
+    if not value then return 0 end
+    local max = Config.Reputation and Config.Reputation.Max
+    if max and max > 0 then return math.min(value, max) end
+    return value
+end
+
+local function loadStats(identifier)
+    if not identifier then return nil end
+    if statsCache[identifier] then return statsCache[identifier] end
+    local raw = GetResourceKvpString(('outlaw_organe:stats:%s'):format(identifier))
+    local data = raw and json.decode(raw) or nil
+    if not data then
+        data = {
+            reputation = 0,
+            contractsCompleted = 0,
+            deliveries = {},
+            totalQuality = 0,
+            bestQuality = 0,
+            sales = 0,
+            upgrades = {}
+        }
+    end
+    data.reputation = clampReputation(data.reputation or 0)
+    statsCache[identifier] = data
+    return data
+end
+
+local function saveStats(identifier)
+    if not identifier then return end
+    local data = statsCache[identifier]
+    if not data then return end
+    SetResourceKvp(('outlaw_organe:stats:%s'):format(identifier), json.encode(data))
+end
+
+local function getStats(src)
+    local identifier = getIdentifier(src)
+    if not identifier then return nil, nil end
+    local data = loadStats(identifier)
+    return data, identifier
+end
+
+local sortedTiers
+local function getSortedTiers()
+    if sortedTiers then return sortedTiers end
+    sortedTiers = {}
+    local tiers = (Config.Reputation and Config.Reputation.Tiers) or {}
+    for _, tier in ipairs(tiers) do table.insert(sortedTiers, tier) end
+    table.sort(sortedTiers, function(a, b)
+        return (a.reputation or 0) < (b.reputation or 0)
+    end)
+    return sortedTiers
+end
+
+local function calculatePriceMultiplier(reputation)
+    local tiers = getSortedTiers()
+    local current = tiers[1] or { name = 'Recrue', reputation = 0, multiplier = 1.0 }
+    local nextTier = nil
+    local multiplier = current.multiplier or 1.0
+    for _, tier in ipairs(tiers) do
+        if reputation >= (tier.reputation or 0) then
+            current = tier
+            multiplier = tier.multiplier or multiplier
+        elseif not nextTier then
+            nextTier = tier
+        end
+    end
+    return multiplier, current, nextTier
+end
 
 local function updateHeat(src, delta)
     heat[src] = heat[src] or { value = 0, updatedAt = now() }
@@ -77,9 +156,19 @@ local function removeItem(src, name, count) return exports.ox_inventory:RemoveIt
 local function hasItem(src, name) return countItem(src, name) > 0 end
 
 local function playerHasScalpel(src)
-    if Config.Scalpel and Config.Scalpel.basic and hasItem(src, Config.Scalpel.basic) then return 'basic' end
-    if Config.Scalpel and Config.Scalpel.pro and hasItem(src, Config.Scalpel.pro) then return 'pro' end
-    return false
+    if not Config.Scalpel or not Config.Scalpel.variants then return nil end
+    local bestKey, bestData = nil, nil
+    for key, data in pairs(Config.Scalpel.variants) do
+        if data.item and hasItem(src, data.item) then
+            if not bestData or (data.bonusQuality or 0) > (bestData.bonusQuality or 0) then
+                bestKey, bestData = key, data
+            end
+        end
+    end
+    if bestKey then
+        return { key = bestKey, data = bestData }
+    end
+    return nil
 end
 
 local function baseQualityFromCause(causeHash)
@@ -103,16 +192,21 @@ local function baseQualityFromCause(causeHash)
     return Q.other
 end
 
-local function pickOrganName(exclude)
+local function pickOrganName(exclude, stats)
     local pool, sum = {}, 0
     exclude = exclude or {}
+    local reputation = stats and (stats.reputation or 0) or 0
     for k, v in pairs(Config.ItemDetails) do
-        if not exclude[k] or (Config.ItemDetails[k].limit or 1) > (exclude[k] or 0) then
-            local price = math.max(1, tonumber(v.price) or 1)
-            local w = math.floor(1000 / price)
-            if w < 1 then w = 1 end
-            sum = sum + w
-            table.insert(pool, {name=k, weight=w})
+        local unlock = tonumber(v.unlockReputation or 0)
+        if reputation >= unlock then
+            if not exclude[k] or (Config.ItemDetails[k].limit or 1) > (exclude[k] or 0) then
+                local price = math.max(1, tonumber(v.price) or 1)
+                local w = math.floor(1000 / price)
+                if v.weight and v.weight > 0 then w = v.weight end
+                if w < 1 then w = 1 end
+                sum = sum + w
+                table.insert(pool, {name=k, weight=w})
+            end
         end
     end
     if sum <= 0 then return 'organe' end
@@ -185,7 +279,9 @@ RegisterNetEvent('outlaw_organ:harvest', function(netId, causeHash)
 
     local scalpelType = playerHasScalpel(src)
     if not scalpelType then
-        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Tu as besoin d’un %s.'):format(Config.Scalpel.basic), type='error'})
+        local baseVariant = Config.Scalpel and Config.Scalpel.variants and Config.Scalpel.variants.basic
+        local label = baseVariant and (baseVariant.label or baseVariant.item) or 'scalpel'
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Tu as besoin d’un %s.'):format(label), type='error'})
     end
 
     if mission.harvested >= 1 and not mission.canSecond then
@@ -194,12 +290,15 @@ RegisterNetEvent('outlaw_organ:harvest', function(netId, causeHash)
 
     if mission.harvested == 0 then
         local canSecond = false
-        if scalpelType == 'pro' and math.random() < (Config.SecondHarvestChance or 0.15) then canSecond = true end
+        local chance = (scalpelType.data and scalpelType.data.secondHarvestChance) or (Config.SecondHarvestChance or 0.0)
+        if chance > 0 and math.random() < chance then canSecond = true end
         mission.canSecond = canSecond
     end
 
     local base = 80 + baseQualityFromCause(causeHash or 0)
-    if scalpelType == 'pro' then base = base + (Config.Scalpel.proQualityBonus or 10) end
+    if scalpelType.data and scalpelType.data.bonusQuality then
+        base = base + scalpelType.data.bonusQuality
+    end
     base = math.max(20, math.min(100, base))
 
     local ttl = Config.OrganDecaySeconds or 600
@@ -211,7 +310,8 @@ RegisterNetEvent('outlaw_organ:harvest', function(netId, causeHash)
     end
 
     mission.given = mission.given or {}
-    local organ = pickOrganName(mission.given)
+    local stats = select(1, getStats(src))
+    local organ = pickOrganName(mission.given, stats)
 
     local born = now()
     local expires = born + ttl
@@ -260,10 +360,255 @@ RegisterNetEvent('outlaw_organ:harvest', function(netId, causeHash)
             TriggerClientEvent('outlaw_organ:clearTarget', src)
             missions[src].netId = nil
             missions[src].startedAt = now()
+            local playerStats, identifier = getStats(src)
+            if playerStats then
+                playerStats.contractsCompleted = (playerStats.contractsCompleted or 0) + 1
+                if Config.Reputation and Config.Reputation.ContractBonus then
+                    playerStats.reputation = clampReputation((playerStats.reputation or 0) + (Config.Reputation.ContractBonus or 0))
+                end
+                playerStats.lastContractAt = now()
+                saveStats(identifier)
+            end
         end
 
         TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Récolte: %s (%d%%)'):format(organ, base), type='success'})
     end)
+end)
+
+local function buildDeliverySnapshot(stats)
+    local deliveries = {}
+    for name, data in pairs(Config.ItemDetails) do
+        table.insert(deliveries, {
+            name = name,
+            label = data.label or name,
+            count = stats and stats.deliveries and (stats.deliveries[name] or 0) or 0,
+            price = data.price or 0,
+            unlock = data.unlockReputation or 0
+        })
+    end
+    table.sort(deliveries, function(a, b)
+        if a.price == b.price then return a.name < b.name end
+        return a.price > b.price
+    end)
+    return deliveries
+end
+
+RegisterNetEvent('outlaw_organ:requestDealerMenu', function()
+    local src = source
+    local stats = select(1, getStats(src))
+    local reputation = stats and (stats.reputation or 0) or 0
+    local multiplier, currentTier, nextTier = calculatePriceMultiplier(reputation)
+    local deliveries = buildDeliverySnapshot(stats)
+    local rareUnlocks = {}
+    if Config.Reputation and Config.Reputation.RareOrders then
+        for item, info in pairs(Config.Reputation.RareOrders) do
+            table.insert(rareUnlocks, {
+                name = item,
+                label = (Config.ItemDetails[item] and Config.ItemDetails[item].label) or item,
+                required = info.reputation or 0,
+                unlocked = reputation >= (info.reputation or 0)
+            })
+        end
+        table.sort(rareUnlocks, function(a, b)
+            return a.required < b.required
+        end)
+    end
+
+    local scalpelInfo = nil
+    local ownedScalpel = playerHasScalpel(src)
+    if ownedScalpel and ownedScalpel.data then
+        scalpelInfo = {
+            key = ownedScalpel.key,
+            label = ownedScalpel.data.label or ownedScalpel.data.item,
+            bonusQuality = ownedScalpel.data.bonusQuality or 0,
+            secondChance = ownedScalpel.data.secondHarvestChance or 0
+        }
+    end
+
+    local upgrades = {}
+    for id, upgrade in pairs((Config.Scalpel and Config.Scalpel.upgrades) or {}) do
+        local variants = Config.Scalpel.variants or {}
+        local fromVariant = variants[upgrade.from or '']
+        local toVariant = variants[upgrade.to or '']
+        if fromVariant and toVariant then
+            local entry = {
+                id = upgrade.id or id,
+                label = toVariant.label or toVariant.item,
+                price = upgrade.price or 0,
+                reputation = upgrade.reputation or 0,
+                deliveries = upgrade.deliveries or {},
+                hasBase = hasItem(src, fromVariant.item),
+                targetOwned = toVariant.item and hasItem(src, toVariant.item)
+            }
+            entry.reasons = {}
+            if entry.targetOwned then
+                entry.status = 'owned'
+            else
+                if reputation < entry.reputation then
+                    table.insert(entry.reasons, ('Réputation %d/%d'):format(reputation, entry.reputation))
+                end
+                if upgrade.deliveries then
+                    for organ, count in pairs(upgrade.deliveries) do
+                        local delivered = stats and stats.deliveries and (stats.deliveries[organ] or 0) or 0
+                        if delivered < count then
+                            table.insert(entry.reasons, ('%s %d/%d'):format((Config.ItemDetails[organ] and Config.ItemDetails[organ].label) or organ, delivered, count))
+                        end
+                    end
+                end
+                if not entry.hasBase then
+                    table.insert(entry.reasons, ('Posséder: %s'):format(fromVariant.label or fromVariant.item))
+                end
+                if #entry.reasons == 0 then
+                    entry.status = 'ready'
+                else
+                    entry.status = 'locked'
+                end
+            end
+            table.insert(upgrades, entry)
+        end
+    end
+    table.sort(upgrades, function(a, b)
+        if a.status == b.status then return (a.reputation or 0) < (b.reputation or 0) end
+        if a.status == 'ready' then return true end
+        if b.status == 'ready' then return false end
+        if a.status == 'owned' then return false end
+        if b.status == 'owned' then return true end
+        return (a.reputation or 0) < (b.reputation or 0)
+    end)
+
+    local variantOffers = {}
+    local kitOffer = nil
+    if Config.Scalpel then
+        local variants = Config.Scalpel.variants or {}
+        for key, variant in pairs(variants) do
+            if variant.buyPrice and variant.buyPrice > 0 then
+                local entry = {
+                    id = key,
+                    label = variant.label or variant.item or key,
+                    price = variant.buyPrice,
+                    reputation = variant.reputation or 0,
+                    bonusQuality = variant.bonusQuality or 0,
+                    secondChance = variant.secondHarvestChance or 0,
+                    locked = variant.reputation and reputation < variant.reputation,
+                    owned = variant.item and hasItem(src, variant.item) or false
+                }
+                table.insert(variantOffers, entry)
+            end
+        end
+        table.sort(variantOffers, function(a, b)
+            if a.price == b.price then return a.label < b.label end
+            return a.price < b.price
+        end)
+
+        if Config.Scalpel.kit then
+            kitOffer = {
+                id = 'kit',
+                label = 'Kit chirurgical',
+                price = 400
+            }
+        end
+    end
+
+    local avgQuality = 0
+    if stats and (stats.sales or 0) > 0 then
+        avgQuality = math.floor((stats.totalQuality or 0) / (stats.sales or 1))
+    end
+
+    TriggerClientEvent('outlaw_organ:openDealerMenu', src, {
+        reputation = reputation,
+        multiplier = multiplier,
+        tier = currentTier,
+        nextTier = nextTier,
+        deliveries = deliveries,
+        rare = rareUnlocks,
+        stats = {
+            contracts = stats and (stats.contractsCompleted or 0) or 0,
+            bestQuality = stats and (stats.bestQuality or 0) or 0,
+            averageQuality = avgQuality,
+            totalSales = stats and (stats.sales or 0) or 0
+        },
+        scalpel = scalpelInfo,
+        upgrades = upgrades,
+        shop = {
+            variants = variantOffers,
+            kit = kitOffer
+        }
+    })
+end)
+
+RegisterNetEvent('outlaw_organ:upgradeScalpel', function(id)
+    local src = source
+    local xPlayer = ESX.GetPlayerFromId(src)
+    if not xPlayer then return end
+
+    local upgrade = Config.Scalpel and Config.Scalpel.upgrades and Config.Scalpel.upgrades[id]
+    if not upgrade then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Amélioration introuvable.', type='error'})
+    end
+
+    local variants = Config.Scalpel.variants or {}
+    local fromVariant = variants[upgrade.from or '']
+    local toVariant = variants[upgrade.to or '']
+    if not fromVariant or not toVariant then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Configuration incomplète.', type='error'})
+    end
+
+    if not hasItem(src, fromVariant.item) then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Tu dois posséder %s.'):format(fromVariant.label or fromVariant.item), type='error'})
+    end
+
+    if hasItem(src, toVariant.item) then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Tu possèdes déjà cette amélioration.', type='error'})
+    end
+
+    local stats, identifier = getStats(src)
+    if not stats then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Statistiques indisponibles.', type='error'})
+    end
+
+    local reputation = stats.reputation or 0
+    if upgrade.reputation and reputation < upgrade.reputation then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Réputation insuffisante.', type='error'})
+    end
+
+    if upgrade.deliveries then
+        for organ, count in pairs(upgrade.deliveries) do
+            local delivered = stats.deliveries and (stats.deliveries[organ] or 0) or 0
+            if delivered < count then
+                local label = (Config.ItemDetails[organ] and Config.ItemDetails[organ].label) or organ
+                return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Livraisons insuffisantes: %s (%d/%d)'):format(label, delivered, count), type='error'})
+            end
+        end
+    end
+
+    local price = upgrade.price or 0
+    if price > 0 and xPlayer.getMoney() < price then
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Pas assez d’argent pour l’amélioration.', type='error'})
+    end
+
+    if price > 0 then
+        xPlayer.removeMoney(price)
+    end
+
+    local removed = exports.ox_inventory:RemoveItem(src, fromVariant.item, 1)
+    if not removed then
+        if price > 0 then xPlayer.addMoney(price) end
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Impossible de retirer ton ancien scalpel.', type='error'})
+    end
+
+    local added = exports.ox_inventory:AddItem(src, toVariant.item, 1)
+    if not added then
+        exports.ox_inventory:AddItem(src, fromVariant.item, 1)
+        if price > 0 then xPlayer.addMoney(price) end
+        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Inventaire plein pour le nouveau scalpel.', type='error'})
+    end
+
+    stats.upgrades = stats.upgrades or {}
+    stats.upgrades[upgrade.to] = now()
+    saveStats(identifier)
+
+    TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Amélioration obtenue: %s'):format(toVariant.label or toVariant.item), type='success'})
+    sendWebhook('Scalpel amélioré', ('**Joueur:** %s\n**Amélioration:** %s -> %s'):format(GetPlayerName(src), fromVariant.item, toVariant.item), 5793266)
 end)
 
 RegisterNetEvent('outlaw_organ:sellOrgans', function()
@@ -273,6 +618,15 @@ RegisterNetEvent('outlaw_organ:sellOrgans', function()
 
     local total = 0
     local t = now()
+    local stats, identifier = getStats(src)
+    local multiplier, currentTier = 1.0, nil
+    if stats then
+        local nextTier
+        multiplier, currentTier, nextTier = calculatePriceMultiplier(stats.reputation or 0)
+    end
+    local saleSummary = { delivered = {}, repGain = 0, qualityPoints = 0, bestQuality = 0, items = 0 }
+    local baseGain = Config.Reputation and Config.Reputation.BaseGainPerItem or 0
+    local qualityWeight = Config.Reputation and Config.Reputation.QualityWeight or 0
 
     for name, data in pairs(Config.ItemDetails) do
         local slots = exports.ox_inventory:Search(src, 'slots', name) or {}
@@ -293,8 +647,19 @@ RegisterNetEvent('outlaw_organ:sellOrgans', function()
                 end
             end
             local final = math.floor(price * (q / 100))
+            final = math.floor(final * (multiplier or 1.0))
             total = total + final
             exports.ox_inventory:RemoveItem(src, name, 1, nil, slot.slot)
+
+            saleSummary.items = saleSummary.items + 1
+            saleSummary.qualityPoints = saleSummary.qualityPoints + q
+            if q > (saleSummary.bestQuality or 0) then saleSummary.bestQuality = q end
+            saleSummary.delivered[name] = (saleSummary.delivered[name] or 0) + 1
+
+            local repValue = (Config.ItemDetails[name] and Config.ItemDetails[name].rep) or 0
+            local gain = baseGain + (repValue * qualityWeight * (q / 100))
+            gain = math.floor(math.max(0, gain))
+            if gain > 0 then saleSummary.repGain = saleSummary.repGain + gain end
         end
     end
 
@@ -303,7 +668,30 @@ RegisterNetEvent('outlaw_organ:sellOrgans', function()
     end
 
     if Config.UseBlackMoney then xPlayer.addAccountMoney('black_money', total) else xPlayer.addMoney(total) end
-    TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Vente: $%s'):format(total), type='success'})
+    if stats then
+        stats.deliveries = stats.deliveries or {}
+        for item, count in pairs(saleSummary.delivered) do
+            stats.deliveries[item] = (stats.deliveries[item] or 0) + count
+        end
+        stats.totalQuality = (stats.totalQuality or 0) + (saleSummary.qualityPoints or 0)
+        if saleSummary.bestQuality and saleSummary.bestQuality > (stats.bestQuality or 0) then
+            stats.bestQuality = saleSummary.bestQuality
+        end
+        stats.sales = (stats.sales or 0) + (saleSummary.items or 0)
+        if saleSummary.repGain and saleSummary.repGain > 0 then
+            stats.reputation = clampReputation((stats.reputation or 0) + saleSummary.repGain)
+        end
+        saveStats(identifier)
+    end
+
+    local msg = ('Vente: $%s'):format(total)
+    if multiplier and multiplier > 1.0 then
+        msg = msg .. (' | Bonus x%.2f'):format(multiplier)
+    end
+    if saleSummary.repGain and saleSummary.repGain > 0 then
+        msg = msg .. (' | Réputation +%d'):format(saleSummary.repGain)
+    end
+    TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=msg, type='success'})
     sendWebhook('Vente d’organes', ('**Joueur:** %s\n**Montant:** $%s'):format(GetPlayerName(src), total), 15844367)
 end)
 
@@ -312,10 +700,31 @@ RegisterNetEvent('outlaw_organ:buyTool', function(kind)
     local xPlayer = ESX.GetPlayerFromId(src)
     if not xPlayer then return end
 
-    local item, price = nil, 0
-    if kind == 'basic' then item = Config.Scalpel.basic; price = 250
-    elseif kind == 'pro' then item = Config.Scalpel.pro; price = 1500
-    elseif kind == 'kit' then item = Config.Scalpel.kit; price = 400 end
+    local item, price, label
+    if kind == 'kit' then
+        item = Config.Scalpel.kit
+        price = 400
+        label = 'Kit chirurgical'
+    else
+        local variants = Config.Scalpel and Config.Scalpel.variants or {}
+        local variant = variants and variants[kind] or nil
+        if variant then
+            if variant.buyPrice and variant.buyPrice > 0 then
+                local stats = select(1, getStats(src))
+                if variant.reputation and variant.reputation > 0 then
+                    local rep = stats and (stats.reputation or 0) or 0
+                    if rep < variant.reputation then
+                        return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Réputation insuffisante pour cet achat.', type='error'})
+                    end
+                end
+                item = variant.item
+                price = variant.buyPrice
+                label = variant.label or variant.item
+            else
+                return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Cet outil doit être débloqué via amélioration.', type='error'})
+            end
+        end
+    end
 
     if not item or item == '' then
         return TriggerClientEvent('ox_lib:notify', src, {title='Organes', description='Indisponible.', type='error'})
@@ -331,7 +740,7 @@ RegisterNetEvent('outlaw_organ:buyTool', function(kind)
     end
 
     xPlayer.removeMoney(price)
-    TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Achat: %s'):format(item), type='success'})
+    TriggerClientEvent('ox_lib:notify', src, {title='Organes', description=('Achat: %s'):format(label or item), type='success'})
 end)
 
 RegisterNetEvent('outlaw_organ:witnessDispatch', function(coords)

--- a/sql/items_esx.sql
+++ b/sql/items_esx.sql
@@ -1,6 +1,7 @@
 INSERT INTO items (name, label, weight) VALUES
 ('scalpel', 'Scalpel', 1),
 ('scalpel_pro', 'Scalpel Pro', 1),
+('scalpel_elite', 'Scalpel Élite', 1),
 ('surgery_kit', 'Kit chirurgical', 2),
 ('cooler', 'Glacière', 5),
 ('icepack', 'Pack de glace', 1),

--- a/ui/app.js
+++ b/ui/app.js
@@ -122,12 +122,30 @@ function renderSummary() {
             <div class="summary-value">${multiplier.toFixed(2)}<span>x</span></div>
             <div class="summary-meta">Appliqué sur les ventes au trafiquant.</div>
         </article>
-        <article class="summary-card">
+        <article class="summary-card summary-card--scalpel">
             <div class="summary-title">Scalpel actif</div>
             <div class="summary-value">${scalpel ? scalpel.label : 'Aucun'}${scalpel ? `<span>+${formatNumber(scalpel.bonusQuality || 0)} qualité</span>` : ''}</div>
             <div class="summary-meta">${scalpel ? `Chance double prélèvement: ${secondChance}%` : 'Achetez un scalpel pour améliorer vos récoltes.'}</div>
+            <div class="summary-actions">
+                <button class="primary-button" id="summary-sell" type="button">Vendre mon stock</button>
+                <button class="secondary-button" data-go-tab="deliveries" type="button">Livraisons</button>
+                <button class="secondary-button" data-go-tab="shop" type="button">Boutique</button>
+            </div>
         </article>
     `;
+
+    const sellBtn = summaryEl.querySelector('#summary-sell');
+    if (sellBtn) {
+        sellBtn.addEventListener('click', () => send('dealer_sell'));
+    }
+    summaryEl.querySelectorAll('[data-go-tab]').forEach((btn) => {
+        btn.addEventListener('click', (event) => {
+            const tab = event.currentTarget.getAttribute('data-go-tab');
+            state.tab = tab;
+            updateTabs();
+            renderActiveTab();
+        });
+    });
 }
 
 function renderOverview() {
@@ -167,25 +185,6 @@ function renderOverview() {
     `;
     overviewEl.appendChild(rareCard);
 
-    const actionsCard = document.createElement('article');
-    actionsCard.className = 'card wide';
-    actionsCard.innerHTML = `
-        <h2>Actions rapides</h2>
-        <p class="list-description">Vends ton stock actuel ou explore la boutique pour débloquer de nouveaux scalpels et consommables.</p>
-        <div class="list-footer">
-            <button class="primary-button" id="action-sell" type="button">Vendre mon stock</button>
-            <div class="button-group">
-                <button class="secondary-button" data-go-tab="deliveries" type="button">Livraisons</button>
-                <button class="secondary-button" data-go-tab="shop" type="button">Boutique</button>
-            </div>
-        </div>
-    `;
-    overviewEl.appendChild(actionsCard);
-
-    const sellBtn = document.getElementById('action-sell');
-    if (sellBtn) {
-        sellBtn.addEventListener('click', () => send('dealer_sell'));
-    }
     overviewEl.querySelectorAll('[data-go-tab]').forEach((btn) => {
         btn.addEventListener('click', (event) => {
             const tab = event.currentTarget.getAttribute('data-go-tab');

--- a/ui/app.js
+++ b/ui/app.js
@@ -200,6 +200,7 @@ function renderDeliveries() {
     const data = state.data || {};
     const deliveries = Array.isArray(data.deliveries) ? data.deliveries : [];
     const reputation = Number(data.reputation || 0);
+    const multiplier = Number(data.multiplier || 1);
     deliveriesEl.innerHTML = '';
 
     if (!deliveries.length) {
@@ -212,10 +213,16 @@ function renderDeliveries() {
         const unlocked = reputation >= unlock;
         const card = document.createElement('article');
         card.className = `list-card${unlocked ? '' : ' locked'}`;
+        const basePrice = Number(delivery.price || 0);
+        const adjustedPrice = basePrice * multiplier;
+        const adjustedLine = multiplier !== 1
+            ? `<div class="list-meta accent">Prix ${multiplier > 1 ? 'bonus' : 'réduit'} (${multiplier.toFixed(2)}x): ${formatCurrency(adjustedPrice)}</div>`
+            : '';
         card.innerHTML = `
             <h3 class="list-title">${delivery.label || delivery.name}</h3>
             <div class="list-meta">Livraisons totales: <strong>${formatNumber(delivery.count || 0)}</strong></div>
-            <div class="list-meta">Prix de base: ${formatCurrency(delivery.price || 0)}</div>
+            <div class="list-meta">Prix de base: ${formatCurrency(basePrice)}</div>
+            ${adjustedLine}
             <div class="list-footer">
                 <span class="tag${unlocked ? ' accent' : ''}">${unlock > 0 ? `${formatNumber(unlock)} RP requis` : 'Disponible'}</span>
             </div>

--- a/ui/app.js
+++ b/ui/app.js
@@ -7,8 +7,8 @@ const rareEl = document.getElementById('rare-content');
 const upgradesEl = document.getElementById('upgrades-content');
 const shopEl = document.getElementById('shop-content');
 const closeBtn = document.getElementById('close-btn');
-const tabButtons = Array.from(document.querySelectorAll('.tab'));
-const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+const tabButtons = Array.from(appEl.querySelectorAll('.tab'));
+const tabPanels = Array.from(appEl.querySelectorAll('.tab-panel'));
 
 const isNui = typeof GetParentResourceName === 'function';
 const resourceName = isNui ? GetParentResourceName() : 'outlaw_organ';

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,0 +1,452 @@
+const appEl = document.getElementById('app');
+const subtitleEl = document.getElementById('panel-subtitle');
+const summaryEl = document.getElementById('summary');
+const overviewEl = document.getElementById('overview-content');
+const deliveriesEl = document.getElementById('deliveries-content');
+const rareEl = document.getElementById('rare-content');
+const upgradesEl = document.getElementById('upgrades-content');
+const shopEl = document.getElementById('shop-content');
+const closeBtn = document.getElementById('close-btn');
+const tabButtons = Array.from(document.querySelectorAll('.tab'));
+const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+
+const isNui = typeof GetParentResourceName === 'function';
+const resourceName = isNui ? GetParentResourceName() : 'outlaw_organ';
+const numberFormat = new Intl.NumberFormat('fr-FR');
+
+const state = {
+    visible: false,
+    tab: 'overview',
+    data: null
+};
+
+function formatNumber(value) {
+    const num = Number.isFinite(value) ? value : 0;
+    return numberFormat.format(Math.round(num));
+}
+
+function formatCurrency(value) {
+    const num = Number.isFinite(value) ? value : 0;
+    return '$' + numberFormat.format(Math.round(num));
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function showApp() {
+    if (state.visible) return;
+    appEl.classList.remove('hidden');
+    state.visible = true;
+}
+
+function hideApp() {
+    if (!state.visible) return;
+    appEl.classList.add('hidden');
+    state.visible = false;
+}
+
+function send(eventName, payload) {
+    if (isNui) {
+        fetch(`https://${resourceName}/${eventName}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload || {})
+        });
+    } else {
+        console.log('[NUI]', eventName, payload);
+    }
+}
+
+function setTab(tab) {
+    if (state.tab === tab) return;
+    state.tab = tab;
+    updateTabs();
+    renderActiveTab();
+}
+
+function updateTabs() {
+    tabButtons.forEach((btn) => {
+        const isActive = btn.dataset.tab === state.tab;
+        btn.classList.toggle('active', isActive);
+    });
+    tabPanels.forEach((panel) => {
+        const isActive = panel.dataset.tab === state.tab;
+        panel.classList.toggle('active', isActive);
+    });
+}
+
+function updateSubtitle() {
+    if (!state.data) {
+        subtitleEl.textContent = '';
+        return;
+    }
+    const parts = [];
+    if (state.data.tier && state.data.tier.name) {
+        parts.push(`Rang ${state.data.tier.name}`);
+    }
+    parts.push(`${formatNumber(state.data.reputation || 0)} RP`);
+    if (Number.isFinite(state.data.multiplier)) {
+        parts.push(`Bonus x${(state.data.multiplier || 1).toFixed(2)}`);
+    }
+    subtitleEl.textContent = parts.join(' • ');
+}
+
+function renderSummary() {
+    if (!state.data) {
+        summaryEl.innerHTML = '';
+        return;
+    }
+
+    const reputation = Number(state.data.reputation || 0);
+    const tier = state.data.tier || {};
+    const nextTier = state.data.nextTier || null;
+    const tierStart = Number(tier.reputation || 0);
+    const tierEnd = nextTier ? Number(nextTier.reputation || 0) : reputation;
+    const progress = nextTier ? clamp((reputation - tierStart) / Math.max(tierEnd - tierStart, 1), 0, 1) : 1;
+    const progressLabel = nextTier ? `Prochain rang: ${nextTier.name} (${formatNumber(tierEnd)} RP)` : 'Rang maximal atteint';
+    const multiplier = Number(state.data.multiplier || 1);
+    const scalpel = state.data.scalpel || null;
+    const secondChance = scalpel ? Math.round((scalpel.secondChance || 0) * 100) : 0;
+
+    summaryEl.innerHTML = `
+        <article class="summary-card rep">
+            <div class="summary-title">Réputation</div>
+            <div class="summary-value">${formatNumber(reputation)}<span>RP</span></div>
+            <div class="summary-meta">${tier.name ? `Rang actuel: ${tier.name}` : 'Rang inconnu'}</div>
+            <div class="progress-bar"><span style="width:${Math.round(progress * 100)}%"></span></div>
+            <div class="summary-meta">${progressLabel}</div>
+        </article>
+        <article class="summary-card">
+            <div class="summary-title">Bonus prix</div>
+            <div class="summary-value">${multiplier.toFixed(2)}<span>x</span></div>
+            <div class="summary-meta">Appliqué sur les ventes au trafiquant.</div>
+        </article>
+        <article class="summary-card">
+            <div class="summary-title">Scalpel actif</div>
+            <div class="summary-value">${scalpel ? scalpel.label : 'Aucun'}${scalpel ? `<span>+${formatNumber(scalpel.bonusQuality || 0)} qualité</span>` : ''}</div>
+            <div class="summary-meta">${scalpel ? `Chance double prélèvement: ${secondChance}%` : 'Achetez un scalpel pour améliorer vos récoltes.'}</div>
+        </article>
+    `;
+}
+
+function renderOverview() {
+    const data = state.data || {};
+    const stats = data.stats || {};
+    const deliveries = Array.isArray(data.deliveries) ? data.deliveries : [];
+    const rare = Array.isArray(data.rare) ? data.rare : [];
+    const unlockedRare = rare.filter((entry) => entry.unlocked).length;
+    const nextRare = rare.find((entry) => !entry.unlocked);
+    const totalDeliveries = deliveries.reduce((sum, entry) => sum + (entry.count || 0), 0);
+
+    overviewEl.innerHTML = '';
+
+    const statsCard = document.createElement('article');
+    statsCard.className = 'card';
+    statsCard.innerHTML = `
+        <h2>Contrats & ventes</h2>
+        <div class="stat-list">
+            <div class="stat-row"><span>Contrats terminés</span><strong>${formatNumber(stats.contracts || 0)}</strong></div>
+            <div class="stat-row"><span>Qualité moyenne</span><strong>${formatNumber(stats.averageQuality || 0)}%</strong></div>
+            <div class="stat-row"><span>Meilleure qualité</span><strong>${formatNumber(stats.bestQuality || 0)}%</strong></div>
+            <div class="stat-row"><span>Organes vendus</span><strong>${formatNumber(stats.totalSales || 0)}</strong></div>
+        </div>
+    `;
+    overviewEl.appendChild(statsCard);
+
+    const rareCard = document.createElement('article');
+    rareCard.className = 'card';
+    rareCard.innerHTML = `
+        <h2>Commandes spéciales</h2>
+        <div class="stat-list">
+            <div class="stat-row"><span>Débloquées</span><strong>${unlockedRare}/${rare.length}</strong></div>
+            <div class="stat-row"><span>Livraisons totales</span><strong>${formatNumber(totalDeliveries)}</strong></div>
+            <div class="stat-row"><span>Prochaine pièce</span><strong>${nextRare ? `${nextRare.label} (${formatNumber(nextRare.required || 0)} RP)` : 'Toutes débloquées'}</strong></div>
+        </div>
+        <button class="secondary-button" data-go-tab="rare" type="button">Voir les commandes</button>
+    `;
+    overviewEl.appendChild(rareCard);
+
+    const actionsCard = document.createElement('article');
+    actionsCard.className = 'card wide';
+    actionsCard.innerHTML = `
+        <h2>Actions rapides</h2>
+        <p class="list-description">Vends ton stock actuel ou explore la boutique pour débloquer de nouveaux scalpels et consommables.</p>
+        <div class="list-footer">
+            <button class="primary-button" id="action-sell" type="button">Vendre mon stock</button>
+            <div class="button-group">
+                <button class="secondary-button" data-go-tab="deliveries" type="button">Livraisons</button>
+                <button class="secondary-button" data-go-tab="shop" type="button">Boutique</button>
+            </div>
+        </div>
+    `;
+    overviewEl.appendChild(actionsCard);
+
+    const sellBtn = document.getElementById('action-sell');
+    if (sellBtn) {
+        sellBtn.addEventListener('click', () => send('dealer_sell'));
+    }
+    overviewEl.querySelectorAll('[data-go-tab]').forEach((btn) => {
+        btn.addEventListener('click', (event) => {
+            const tab = event.currentTarget.getAttribute('data-go-tab');
+            state.tab = tab;
+            updateTabs();
+            renderActiveTab();
+        });
+    });
+}
+
+function renderDeliveries() {
+    const data = state.data || {};
+    const deliveries = Array.isArray(data.deliveries) ? data.deliveries : [];
+    const reputation = Number(data.reputation || 0);
+    deliveriesEl.innerHTML = '';
+
+    if (!deliveries.length) {
+        deliveriesEl.innerHTML = '<div class="empty-placeholder">Aucune livraison enregistrée pour le moment.</div>';
+        return;
+    }
+
+    deliveries.forEach((delivery) => {
+        const unlock = Number(delivery.unlock || 0);
+        const unlocked = reputation >= unlock;
+        const card = document.createElement('article');
+        card.className = `list-card${unlocked ? '' : ' locked'}`;
+        card.innerHTML = `
+            <h3 class="list-title">${delivery.label || delivery.name}</h3>
+            <div class="list-meta">Livraisons totales: <strong>${formatNumber(delivery.count || 0)}</strong></div>
+            <div class="list-meta">Prix de base: ${formatCurrency(delivery.price || 0)}</div>
+            <div class="list-footer">
+                <span class="tag${unlocked ? ' accent' : ''}">${unlock > 0 ? `${formatNumber(unlock)} RP requis` : 'Disponible'}</span>
+            </div>
+        `;
+        deliveriesEl.appendChild(card);
+    });
+}
+
+function renderRare() {
+    const data = state.data || {};
+    const rare = Array.isArray(data.rare) ? data.rare : [];
+    rareEl.innerHTML = '';
+
+    if (!rare.length) {
+        rareEl.innerHTML = '<div class="empty-placeholder">Aucune commande rare disponible.</div>';
+        return;
+    }
+
+    rare.forEach((entry) => {
+        const unlocked = Boolean(entry.unlocked);
+        const card = document.createElement('article');
+        card.className = `list-card${unlocked ? '' : ' locked'}`;
+        card.innerHTML = `
+            <h3 class="list-title">${entry.label || entry.name}</h3>
+            <div class="list-meta">Réputation requise: ${formatNumber(entry.required || 0)} RP</div>
+            <div class="list-footer">
+                <span class="tag${unlocked ? ' accent' : ''}">${unlocked ? 'Débloqué' : 'Verrouillé'}</span>
+            </div>
+        `;
+        rareEl.appendChild(card);
+    });
+}
+
+function renderUpgrades() {
+    const data = state.data || {};
+    const upgrades = Array.isArray(data.upgrades) ? data.upgrades : [];
+    upgradesEl.innerHTML = '';
+
+    if (!upgrades.length) {
+        upgradesEl.innerHTML = '<div class="empty-placeholder">Aucune amélioration disponible pour le moment.</div>';
+        return;
+    }
+
+    upgrades.forEach((upgrade) => {
+        const card = document.createElement('article');
+        card.className = 'list-card';
+        const status = upgrade.status || 'locked';
+        const price = Number(upgrade.price || 0);
+        const requirements = Array.isArray(upgrade.reasons) ? upgrade.reasons : [];
+        const requirementsHtml = requirements.length
+            ? requirements.map((reason) => `<span>${reason}</span>`).join('')
+            : '<span>Toutes les conditions sont réunies.</span>';
+
+        card.innerHTML = `
+            <h3 class="list-title">${upgrade.label}</h3>
+            <div class="list-meta">Prix: ${formatCurrency(price)}</div>
+            <div class="list-meta">Réputation requise: ${formatNumber(upgrade.reputation || 0)} RP</div>
+            <div class="requirements">${requirementsHtml}</div>
+            <div class="list-footer">
+                <span class="tag${status === 'ready' ? ' accent' : ''}">${status === 'ready' ? 'Disponible' : status === 'owned' ? 'Obtenu' : 'Verrouillé'}</span>
+                <button class="${status === 'ready' ? 'primary-button' : 'secondary-button'}" type="button" data-upgrade="${upgrade.id}" ${status === 'ready' ? '' : 'disabled'}>${status === 'ready' ? `Débloquer (${formatCurrency(price)})` : 'Indisponible'}</button>
+            </div>
+        `;
+
+        const button = card.querySelector('[data-upgrade]');
+        if (button && status === 'ready') {
+            button.addEventListener('click', () => {
+                send('dealer_upgrade', { id: upgrade.id });
+            });
+        }
+        upgradesEl.appendChild(card);
+    });
+}
+
+function renderShop() {
+    const data = state.data || {};
+    const shop = data.shop || {};
+    const variants = Array.isArray(shop.variants) ? shop.variants : [];
+    const kit = shop.kit || null;
+    shopEl.innerHTML = '';
+
+    if (!variants.length && !kit) {
+        shopEl.innerHTML = '<div class="empty-placeholder">Aucun outil disponible à l’achat.</div>';
+        return;
+    }
+
+    const items = [...variants];
+    if (kit) {
+        items.push({ ...kit, isKit: true });
+    }
+
+    items.forEach((item) => {
+        const card = document.createElement('article');
+        card.className = 'list-card';
+        let description = '';
+        if (!item.isKit) {
+            const chance = Math.round((item.secondChance || 0) * 100);
+            description = `Bonus qualité: +${formatNumber(item.bonusQuality || 0)} | Chance double: ${chance}%`;
+        } else {
+            description = 'Ajoute du temps de conservation supplémentaire pour les organes.';
+        }
+
+        const isLocked = Boolean(item.locked);
+        const isOwned = Boolean(item.owned);
+        const buttonText = item.isKit ? `Acheter (${formatCurrency(item.price || 0)})` : `Acheter (${formatCurrency(item.price || 0)})`;
+
+        card.innerHTML = `
+            <h3 class="list-title">${item.label}</h3>
+            <div class="list-meta">${item.isKit ? '' : `Réputation requise: ${formatNumber(item.reputation || 0)} RP`}</div>
+            <div class="list-description">${description}</div>
+            <div class="list-footer">
+                <span class="tag${!isLocked && !item.isKit ? ' accent' : ''}">${item.isKit ? 'Consommable' : isLocked ? 'Réputation requise' : (isOwned ? 'Possédé' : 'Disponible')}</span>
+                <button class="${!isLocked && !isOwned ? 'primary-button' : 'secondary-button'}" type="button" data-shop-id="${item.id}" ${(!isLocked && !isOwned) ? '' : 'disabled'}>${isOwned ? 'Possédé' : isLocked ? 'Verrouillé' : buttonText}</button>
+            </div>
+        `;
+
+        const button = card.querySelector('[data-shop-id]');
+        if (button && !isLocked && !isOwned) {
+            button.addEventListener('click', () => {
+                send('dealer_buy', { id: item.id });
+            });
+        }
+
+        shopEl.appendChild(card);
+    });
+}
+
+function renderActiveTab() {
+    switch (state.tab) {
+        case 'overview':
+            renderOverview();
+            break;
+        case 'deliveries':
+            renderDeliveries();
+            break;
+        case 'rare':
+            renderRare();
+            break;
+        case 'upgrades':
+            renderUpgrades();
+            break;
+        case 'shop':
+            renderShop();
+            break;
+        default:
+            renderOverview();
+            break;
+    }
+}
+
+function renderAll() {
+    updateSubtitle();
+    renderSummary();
+    updateTabs();
+    renderActiveTab();
+}
+
+closeBtn.addEventListener('click', () => {
+    hideApp();
+    send('dealer_close');
+});
+
+document.addEventListener('keydown', (event) => {
+    if (!state.visible) return;
+    if (event.key === 'Escape') {
+        event.preventDefault();
+        hideApp();
+        send('dealer_close');
+    }
+});
+
+tabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab;
+        state.tab = tab;
+        updateTabs();
+        renderActiveTab();
+    });
+});
+
+window.addEventListener('message', (event) => {
+    const { action, payload } = event.data || {};
+    if (action === 'openDealer') {
+        state.data = payload || {};
+        state.tab = 'overview';
+        renderAll();
+        showApp();
+    } else if (action === 'closeDealer') {
+        hideApp();
+    } else if (action === 'updateDealer') {
+        state.data = payload || state.data;
+        if (state.visible) {
+            renderAll();
+        }
+    }
+});
+
+if (!isNui) {
+    window.addEventListener('DOMContentLoaded', () => {
+        const sampleData = {
+            reputation: 350,
+            multiplier: 1.25,
+            tier: { name: 'Dissecteur', reputation: 320 },
+            nextTier: { name: 'Chirurgien', reputation: 620 },
+            scalpel: { label: 'Scalpel (pro)', bonusQuality: 10, secondChance: 0.2 },
+            stats: { contracts: 12, averageQuality: 82, bestQuality: 96, totalSales: 54 },
+            deliveries: [
+                { name: 'rein', label: 'Rein', count: 32, price: 400, unlock: 0 },
+                { name: 'coeur', label: 'Cœur', count: 6, price: 900, unlock: 320 },
+                { name: 'yeux', label: 'Yeux', count: 14, price: 250, unlock: 120 }
+            ],
+            rare: [
+                { name: 'coeur', label: 'Commande cœur', required: 320, unlocked: true },
+                { name: 'cerveau', label: 'Commande cranienne', required: 580, unlocked: false }
+            ],
+            upgrades: [
+                { id: 'elite', label: 'Scalpel (élite)', price: 5500, reputation: 380, status: 'ready', reasons: [] },
+                { id: 'mythic', label: 'Scalpel (mythique)', price: 7800, reputation: 800, status: 'locked', reasons: ['Réputation 350/800', 'Cœur 6/12'] }
+            ],
+            shop: {
+                variants: [
+                    { id: 'basic', label: 'Scalpel (basique)', price: 250, reputation: 0, bonusQuality: 0, secondChance: 0, locked: false, owned: false },
+                    { id: 'pro', label: 'Scalpel (pro)', price: 1500, reputation: 120, bonusQuality: 10, secondChance: 0.2, locked: false, owned: true },
+                    { id: 'elite', label: 'Scalpel (élite)', price: 2800, reputation: 380, bonusQuality: 18, secondChance: 0.35, locked: true, owned: false }
+                ],
+                kit: { id: 'kit', label: 'Kit chirurgical', price: 400 }
+            }
+        };
+        state.data = sampleData;
+        state.tab = 'overview';
+        renderAll();
+        showApp();
+    });
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Outlaw Organ Dealer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="app" class="hidden">
+        <div class="overlay">
+            <div class="panel">
+                <header class="panel-header">
+                    <div class="panel-titles">
+                        <h1>Progression &amp; réputation</h1>
+                        <p id="panel-subtitle"></p>
+                    </div>
+                    <button id="close-btn" class="ghost-button" type="button" title="Fermer">✕</button>
+                </header>
+                <section id="summary" class="summary-grid"></section>
+                <nav class="tab-bar">
+                    <button class="tab active" data-tab="overview">Aperçu</button>
+                    <button class="tab" data-tab="deliveries">Livraisons</button>
+                    <button class="tab" data-tab="rare">Commandes rares</button>
+                    <button class="tab" data-tab="upgrades">Améliorations</button>
+                    <button class="tab" data-tab="shop">Boutique</button>
+                </nav>
+                <main class="tab-content">
+                    <section class="tab-panel active" data-tab="overview">
+                        <div id="overview-content" class="panel-grid"></div>
+                    </section>
+                    <section class="tab-panel" data-tab="deliveries">
+                        <div id="deliveries-content" class="list-grid"></div>
+                    </section>
+                    <section class="tab-panel" data-tab="rare">
+                        <div id="rare-content" class="list-grid"></div>
+                    </section>
+                    <section class="tab-panel" data-tab="upgrades">
+                        <div id="upgrades-content" class="list-grid"></div>
+                    </section>
+                    <section class="tab-panel" data-tab="shop">
+                        <div id="shop-content" class="list-grid"></div>
+                    </section>
+                </main>
+            </div>
+        </div>
+    </div>
+    <script src="app.js" defer></script>
+</body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -13,7 +13,7 @@
             <div class="panel">
                 <header class="panel-header">
                     <div class="panel-titles">
-                        <h1>Progression &amp; réputation</h1>
+                        <h1>Progression clandestine</h1>
                         <p id="panel-subtitle"></p>
                     </div>
                     <button id="close-btn" class="ghost-button" type="button" title="Fermer">✕</button>

--- a/ui/index.html
+++ b/ui/index.html
@@ -56,23 +56,33 @@
                     </div>
                     <button id="mission-close-btn" class="ghost-button" type="button" title="Fermer">✕</button>
                 </header>
-                <section id="mission-summary" class="summary-grid"></section>
-                <nav class="tab-bar">
-                    <button class="tab active" data-mission-tab="progress">Progression</button>
-                    <button class="tab" data-mission-tab="contracts">Contrats</button>
-                    <button class="tab" data-mission-tab="pool">Butin</button>
-                </nav>
-                <main class="tab-content">
-                    <section class="tab-panel active" data-mission-tab="progress">
-                        <div id="mission-progress-content" class="list-grid"></div>
-                    </section>
-                    <section class="tab-panel" data-mission-tab="contracts">
-                        <div id="mission-contracts-content" class="list-grid"></div>
-                    </section>
-                    <section class="tab-panel" data-mission-tab="pool">
-                        <div id="mission-pool-content" class="list-grid"></div>
-                    </section>
-                </main>
+                <section id="mission-overview" class="summary-grid"></section>
+                <section class="mission-sections">
+                    <article class="mission-section-card">
+                        <header class="mission-section-header">
+                            <h2>Progression</h2>
+                        </header>
+                        <div class="mission-section-body">
+                            <div id="mission-progress-content" class="list-grid"></div>
+                        </div>
+                    </article>
+                    <article class="mission-section-card">
+                        <header class="mission-section-header">
+                            <h2>Contrats ciblés</h2>
+                        </header>
+                        <div class="mission-section-body">
+                            <div id="mission-contracts-content" class="list-grid"></div>
+                        </div>
+                    </article>
+                    <article class="mission-section-card">
+                        <header class="mission-section-header">
+                            <h2>Butin aléatoire</h2>
+                        </header>
+                        <div class="mission-section-body">
+                            <div id="mission-pool-content" class="list-grid"></div>
+                        </div>
+                    </article>
+                </section>
             </div>
         </div>
     </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -46,6 +46,37 @@
             </div>
         </div>
     </div>
+    <div id="mission-app" class="hidden">
+        <div class="overlay">
+            <div class="panel">
+                <header class="panel-header">
+                    <div class="panel-titles">
+                        <h1>Tableau des missions</h1>
+                        <p id="mission-subtitle"></p>
+                    </div>
+                    <button id="mission-close-btn" class="ghost-button" type="button" title="Fermer">✕</button>
+                </header>
+                <section id="mission-summary" class="summary-grid"></section>
+                <nav class="tab-bar">
+                    <button class="tab active" data-mission-tab="progress">Progression</button>
+                    <button class="tab" data-mission-tab="contracts">Contrats</button>
+                    <button class="tab" data-mission-tab="pool">Butin</button>
+                </nav>
+                <main class="tab-content">
+                    <section class="tab-panel active" data-mission-tab="progress">
+                        <div id="mission-progress-content" class="list-grid"></div>
+                    </section>
+                    <section class="tab-panel" data-mission-tab="contracts">
+                        <div id="mission-contracts-content" class="list-grid"></div>
+                    </section>
+                    <section class="tab-panel" data-mission-tab="pool">
+                        <div id="mission-pool-content" class="list-grid"></div>
+                    </section>
+                </main>
+            </div>
+        </div>
+    </div>
     <script src="app.js" defer></script>
+    <script src="mission.js" defer></script>
 </body>
 </html>

--- a/ui/mission.js
+++ b/ui/mission.js
@@ -127,6 +127,16 @@ if (missionAppEl) {
             quickDisabled = true;
         }
 
+        const contractActive = active && active.type === 'contract';
+        const canFinish = contractActive && Boolean(active.ready);
+        let quickButtonClass = 'primary-button';
+        let finishButton = '';
+        if (contractActive) {
+            quickButtonClass = 'secondary-button';
+            const label = canFinish ? 'Terminer mission' : 'Mission spéciale';
+            finishButton = `<button class="primary-button" id="mission-finish" type="button" ${canFinish ? '' : 'disabled'}>${label}</button>`;
+        }
+
         missionSummaryEl.innerHTML = `
             <article class="summary-card rep">
                 <div class="summary-title">Réputation</div>
@@ -144,12 +154,21 @@ if (missionAppEl) {
                 <div class="summary-title">Actions rapides</div>
                 <div class="summary-meta">Gère tes contrats depuis la planque.</div>
                 <div class="summary-actions">
-                    <button class="primary-button" id="mission-quickstart" type="button" ${quickDisabled ? 'disabled' : ''}>${quickLabel}</button>
+                    ${finishButton}
+                    <button class="${quickButtonClass}" id="mission-quickstart" type="button" ${quickDisabled ? 'disabled' : ''}>${quickLabel}</button>
                     <button class="secondary-button" data-go-mission-tab="contracts" type="button">Voir les contrats</button>
                 </div>
             </article>
         `;
 
+        const finishBtn = missionSummaryEl.querySelector('#mission-finish');
+        if (finishBtn && canFinish) {
+            finishBtn.addEventListener('click', () => {
+                if (typeof send === 'function') {
+                    send('mission_finish', {});
+                }
+            });
+        }
         const quickBtn = missionSummaryEl.querySelector('#mission-quickstart');
         if (quickBtn && !quickDisabled) {
             quickBtn.addEventListener('click', () => {

--- a/ui/mission.js
+++ b/ui/mission.js
@@ -1,0 +1,430 @@
+const missionAppEl = document.getElementById('mission-app');
+if (missionAppEl) {
+    const missionSubtitleEl = document.getElementById('mission-subtitle');
+    const missionSummaryEl = document.getElementById('mission-summary');
+    const missionProgressEl = document.getElementById('mission-progress-content');
+    const missionContractsEl = document.getElementById('mission-contracts-content');
+    const missionPoolEl = document.getElementById('mission-pool-content');
+    const missionCloseBtn = document.getElementById('mission-close-btn');
+    const missionTabButtons = Array.from(missionAppEl.querySelectorAll('[data-mission-tab]'));
+    const missionTabPanels = Array.from(missionAppEl.querySelectorAll('.tab-panel'));
+
+    const missionNumberFormat = new Intl.NumberFormat('fr-FR');
+
+    const missionState = {
+        visible: false,
+        tab: 'progress',
+        data: null
+    };
+
+    function formatNumber(value) {
+        const num = Number.isFinite(value) ? value : 0;
+        return missionNumberFormat.format(Math.round(num));
+    }
+
+    function formatCurrency(value) {
+        const num = Number.isFinite(value) ? value : 0;
+        return '$' + missionNumberFormat.format(Math.round(num));
+    }
+
+    function formatDuration(seconds) {
+        const total = Math.max(0, Math.floor(seconds || 0));
+        const hours = Math.floor(total / 3600);
+        const minutes = Math.floor((total % 3600) / 60);
+        const secs = total % 60;
+        if (hours > 0) {
+            return `${hours}h${String(minutes).padStart(2, '0')}m`;
+        }
+        return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+    }
+
+    function showMissionApp() {
+        if (missionState.visible) return;
+        missionAppEl.classList.remove('hidden');
+        missionState.visible = true;
+    }
+
+    function hideMissionApp() {
+        if (!missionState.visible) return;
+        missionAppEl.classList.add('hidden');
+        missionState.visible = false;
+    }
+
+    function updateMissionTabs() {
+        missionTabButtons.forEach((btn) => {
+            const isActive = btn.dataset.missionTab === missionState.tab;
+            btn.classList.toggle('active', isActive);
+        });
+        missionTabPanels.forEach((panel) => {
+            const isActive = panel.dataset.missionTab === missionState.tab;
+            panel.classList.toggle('active', isActive);
+        });
+    }
+
+    function updateMissionSubtitle() {
+        const data = missionState.data;
+        if (!data) {
+            missionSubtitleEl.textContent = '';
+            return;
+        }
+        const parts = [];
+        const rep = Number(data.reputation || 0);
+        parts.push(`${formatNumber(rep)} RP`);
+        if (Number.isFinite(data.unlockedCount) && Number.isFinite(data.totalContracts)) {
+            parts.push(`${formatNumber(data.unlockedCount || 0)}/${formatNumber(data.totalContracts || 0)} débloqués`);
+        }
+        const cooldown = Math.max(0, Number(data.cooldown || 0));
+        if (cooldown > 0) {
+            parts.push(`Cooldown ${formatDuration(cooldown)}`);
+        }
+        missionSubtitleEl.textContent = parts.join(' • ');
+    }
+
+    function renderMissionSummary() {
+        const data = missionState.data;
+        if (!data) {
+            missionSummaryEl.innerHTML = '';
+            return;
+        }
+
+        const rep = Number(data.reputation || 0);
+        const unlockedCount = Number(data.unlockedCount || 0);
+        const totalContracts = Number(data.totalContracts || 0);
+        const stats = data.stats || {};
+        const active = data.active || null;
+        const cooldown = Math.max(0, Number(data.cooldown || 0));
+        const canStartRandom = Boolean(data.canStartRandom);
+        const nextUnlock = data.nextUnlock || null;
+
+        const nextLine = nextUnlock
+            ? `Prochain contrat: ${nextUnlock.label} (${Math.round((nextUnlock.progress || 0) * 100)}%)`
+            : 'Tous les contrats sont débloqués.';
+
+        const deliveriesLine = `Livraisons totales: ${formatNumber(stats.totalDelivered || 0)}`;
+        const contractsLine = `Contrats terminés: ${formatNumber(stats.contracts || 0)}`;
+
+        let activeLine = 'Aucune mission en cours.';
+        if (active) {
+            const label = active.itemLabel ? `${active.label} • ${active.itemLabel}` : active.label;
+            if (active.remaining && active.remaining > 0) {
+                activeLine = `${label} — ${formatDuration(active.remaining)} restantes`;
+            } else {
+                activeLine = `${label}`;
+            }
+        } else if (cooldown > 0) {
+            activeLine = `Disponible après ${formatDuration(cooldown)}`;
+        }
+
+        let quickLabel = 'Mission express';
+        let quickDisabled = false;
+        if (active) {
+            quickLabel = 'Mission active';
+            quickDisabled = true;
+        } else if (cooldown > 0) {
+            quickLabel = `Cooldown (${formatDuration(cooldown)})`;
+            quickDisabled = true;
+        } else if (!canStartRandom) {
+            quickDisabled = true;
+        }
+
+        missionSummaryEl.innerHTML = `
+            <article class="summary-card rep">
+                <div class="summary-title">Réputation</div>
+                <div class="summary-value">${formatNumber(rep)}<span>RP</span></div>
+                <div class="summary-meta">Contrats débloqués: ${formatNumber(unlockedCount)}/${formatNumber(totalContracts)}</div>
+                <div class="summary-meta">${nextLine}</div>
+            </article>
+            <article class="summary-card">
+                <div class="summary-title">Statut</div>
+                <div class="summary-meta">${contractsLine}</div>
+                <div class="summary-meta">${deliveriesLine}</div>
+                <div class="summary-meta">${activeLine}</div>
+            </article>
+            <article class="summary-card summary-card--actions">
+                <div class="summary-title">Actions rapides</div>
+                <div class="summary-meta">Gère tes contrats depuis la planque.</div>
+                <div class="summary-actions">
+                    <button class="primary-button" id="mission-quickstart" type="button" ${quickDisabled ? 'disabled' : ''}>${quickLabel}</button>
+                    <button class="secondary-button" data-go-mission-tab="contracts" type="button">Voir les contrats</button>
+                </div>
+            </article>
+        `;
+
+        const quickBtn = missionSummaryEl.querySelector('#mission-quickstart');
+        if (quickBtn && !quickDisabled) {
+            quickBtn.addEventListener('click', () => {
+                if (typeof send === 'function') {
+                    send('mission_start', {});
+                }
+            });
+        }
+        missionSummaryEl.querySelectorAll('[data-go-mission-tab]').forEach((btn) => {
+            btn.addEventListener('click', (event) => {
+                const tab = event.currentTarget.getAttribute('data-go-mission-tab');
+                missionState.tab = tab;
+                updateMissionTabs();
+                renderMissionActiveTab();
+            });
+        });
+    }
+
+    function renderMissionProgress() {
+        const data = missionState.data || {};
+        const contracts = Array.isArray(data.contracts) ? data.contracts : [];
+        missionProgressEl.innerHTML = '';
+
+        if (!contracts.length) {
+            missionProgressEl.innerHTML = '<div class="empty-placeholder">Aucun contrat configuré.</div>';
+            return;
+        }
+
+        contracts.forEach((contract) => {
+            const card = document.createElement('article');
+            card.className = 'list-card';
+            if (!contract.unlocked) {
+                card.classList.add('locked');
+            }
+            const percent = Math.round((contract.progress || 0) * 100);
+            const reqs = Array.isArray(contract.requirements) ? contract.requirements : [];
+            const requirementsHtml = reqs.length
+                ? reqs.map((req) => {
+                    const required = Number(req.required || 0);
+                    const have = Number(req.value || 0);
+                    const ratio = required > 0 ? Math.min(1, have / required) : 1;
+                    const label = req.label || (req.type === 'reputation' ? 'Réputation' : req.name || 'Objectif');
+                    return `
+                        <div class="requirement-row">
+                            <div class="requirement-row-header">
+                                <span>${label}</span>
+                                <strong>${formatNumber(have)}/${formatNumber(required)}</strong>
+                            </div>
+                            <div class="progress-bar progress-bar--thin"><span style="width:${Math.round(ratio * 100)}%"></span></div>
+                        </div>
+                    `;
+                }).join('')
+                : '<span>Aucune exigence.</span>';
+
+            const historyLine = contract.completed > 0
+                ? `Terminé ${formatNumber(contract.completed)} fois${contract.bestTime ? ` • Record ${formatDuration(contract.bestTime)}` : ''}`
+                : 'Pas encore terminé.';
+
+            card.innerHTML = `
+                <div class="list-header">
+                    <h3 class="list-title">${contract.label}</h3>
+                    <span class="tag${contract.unlocked ? ' accent' : ''}">${contract.unlocked ? 'Débloqué' : 'Verrouillé'}</span>
+                </div>
+                <div class="list-meta">Progression globale: ${percent}%</div>
+                <div class="requirements requirements--progress">${requirementsHtml}</div>
+                <div class="list-meta">${historyLine}</div>
+            `;
+
+            missionProgressEl.appendChild(card);
+        });
+    }
+
+    function renderMissionContracts() {
+        const data = missionState.data || {};
+        const contracts = Array.isArray(data.contracts) ? data.contracts : [];
+        missionContractsEl.innerHTML = '';
+
+        if (!contracts.length) {
+            missionContractsEl.innerHTML = '<div class="empty-placeholder">Aucun contrat disponible pour le moment.</div>';
+            return;
+        }
+
+        const hasActive = Boolean(data.active);
+        const cooldown = Math.max(0, Number(data.cooldown || 0));
+
+        contracts.forEach((contract) => {
+            const card = document.createElement('article');
+            card.className = 'list-card';
+            if (!contract.unlocked) {
+                card.classList.add('locked');
+            }
+
+            const fee = Number(contract.fee || 0);
+            const priceLabel = fee > 0 ? formatCurrency(fee) : 'Gratuit';
+            const timeLabel = contract.timeLimit > 0 ? formatDuration(contract.timeLimit) : '—';
+            const bonusLine = contract.bonusReputation > 0
+                ? `<div class="list-meta">Bonus réputation: +${formatNumber(contract.bonusReputation)}</div>`
+                : '';
+            const timeLine = contract.timeLimit > 0
+                ? `<div class="list-meta">Temps limite: ${timeLabel}</div>`
+                : '';
+            const historyLine = contract.completed > 0
+                ? `<div class="list-meta">Succès: ${formatNumber(contract.completed)}${contract.bestTime ? ` • Record ${formatDuration(contract.bestTime)}` : ''}</div>`
+                : '';
+            const description = contract.description || 'Aucune description.';
+
+            let tagText;
+            let tagAccent = false;
+            let buttonLabel;
+            let buttonDisabled = false;
+
+            if (data.active && data.active.id === contract.id) {
+                tagText = 'En cours';
+                tagAccent = true;
+                buttonLabel = 'Mission en cours';
+                buttonDisabled = true;
+            } else if (!contract.unlocked) {
+                tagText = 'Verrouillé';
+                buttonLabel = 'Verrouillé';
+                buttonDisabled = true;
+            } else if (hasActive) {
+                tagText = 'Mission active';
+                buttonLabel = 'Mission active';
+                buttonDisabled = true;
+            } else if (cooldown > 0) {
+                tagText = 'Cooldown';
+                buttonLabel = `Attends ${formatDuration(cooldown)}`;
+                buttonDisabled = true;
+            } else {
+                tagText = 'Disponible';
+                tagAccent = true;
+                buttonLabel = fee > 0 ? `Acheter (${priceLabel})` : 'Démarrer';
+            }
+
+            const reasons = Array.isArray(contract.reasons) ? contract.reasons : [];
+            const reasonHtml = !contract.unlocked && reasons.length
+                ? `<div class="requirements">${reasons.map((reason) => `<span>${reason}</span>`).join('')}</div>`
+                : '';
+
+            card.innerHTML = `
+                <div class="list-header">
+                    <h3 class="list-title">${contract.label}</h3>
+                    <span class="list-price">${priceLabel}</span>
+                </div>
+                <div class="list-description">${description}</div>
+                ${timeLine}
+                ${bonusLine}
+                ${historyLine}
+                ${reasonHtml}
+                <div class="list-footer">
+                    <span class="tag${tagAccent ? ' accent' : ''}">${tagText}</span>
+                    <button class="${(!buttonDisabled) ? 'primary-button' : 'secondary-button'}" type="button" data-contract-id="${contract.id}" ${buttonDisabled ? 'disabled' : ''}>${buttonLabel}</button>
+                </div>
+            `;
+
+            const button = card.querySelector('[data-contract-id]');
+            if (button && !buttonDisabled) {
+                button.addEventListener('click', () => {
+                    if (typeof send === 'function') {
+                        send('mission_start', { contract: contract.id });
+                    }
+                });
+            }
+
+            missionContractsEl.appendChild(card);
+        });
+    }
+
+    function renderMissionPool() {
+        const data = missionState.data || {};
+        const pool = data.pool || {};
+        const unlocked = Array.isArray(pool.unlocked) ? pool.unlocked : [];
+        const locked = Array.isArray(pool.locked) ? pool.locked : [];
+        missionPoolEl.innerHTML = '';
+
+        const contractMap = new Map();
+        if (Array.isArray(data.contracts)) {
+            data.contracts.forEach((contract) => {
+                contractMap.set(contract.id, contract);
+            });
+        }
+
+        if (!unlocked.length && !locked.length) {
+            missionPoolEl.innerHTML = '<div class="empty-placeholder">Aucun organe configuré.</div>';
+            return;
+        }
+
+        const renderItem = (item, available) => {
+            const card = document.createElement('article');
+            card.className = `list-card list-card--compact${available ? '' : ' locked'}`;
+            const contract = contractMap.get(item.id);
+            let reasonBlock = '';
+            if (!available && contract && Array.isArray(contract.reasons) && contract.reasons.length) {
+                reasonBlock = `<div class="requirements">${contract.reasons.map((reason) => `<span>${reason}</span>`).join('')}</div>`;
+            }
+            card.innerHTML = `
+                <h3 class="list-title">${item.label}</h3>
+                <div class="list-meta">${available ? 'Disponible dans les missions aléatoires.' : 'Encore verrouillé.'}</div>
+                ${reasonBlock}
+                <div class="list-footer">
+                    <span class="tag${available ? ' accent' : ''}">${available ? 'Disponible' : 'Verrouillé'}</span>
+                </div>
+            `;
+            missionPoolEl.appendChild(card);
+        };
+
+        unlocked.forEach((item) => renderItem(item, true));
+        locked.forEach((item) => renderItem(item, false));
+    }
+
+    function renderMissionActiveTab() {
+        switch (missionState.tab) {
+            case 'progress':
+                renderMissionProgress();
+                break;
+            case 'contracts':
+                renderMissionContracts();
+                break;
+            case 'pool':
+                renderMissionPool();
+                break;
+            default:
+                renderMissionProgress();
+                break;
+        }
+    }
+
+    function renderMissionAll() {
+        updateMissionSubtitle();
+        renderMissionSummary();
+        updateMissionTabs();
+        renderMissionActiveTab();
+    }
+
+    missionCloseBtn.addEventListener('click', () => {
+        hideMissionApp();
+        if (typeof send === 'function') {
+            send('mission_close');
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (!missionState.visible) return;
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            hideMissionApp();
+            if (typeof send === 'function') {
+                send('mission_close');
+            }
+        }
+    });
+
+    missionTabButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const tab = btn.dataset.missionTab;
+            missionState.tab = tab;
+            updateMissionTabs();
+            renderMissionActiveTab();
+        });
+    });
+
+    window.addEventListener('message', (event) => {
+        const { action, payload } = event.data || {};
+        if (action === 'openMission') {
+            missionState.data = payload || {};
+            missionState.tab = 'progress';
+            renderMissionAll();
+            showMissionApp();
+        } else if (action === 'closeMission') {
+            hideMissionApp();
+        } else if (action === 'updateMission') {
+            missionState.data = payload || missionState.data;
+            if (missionState.visible) {
+                renderMissionAll();
+            }
+        }
+    });
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -241,14 +241,14 @@ body {
 .tab-content > .tab-panel {
     flex: 1;
     display: none;
-    overflow: hidden;
 }
 
 .tab-panel.active {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    overflow: hidden;
+    overflow-y: auto;
+    padding-right: 4px;
 }
 
 .panel-grid {

--- a/ui/style.css
+++ b/ui/style.css
@@ -47,6 +47,7 @@ body {
     max-height: 82vh;
     display: flex;
     flex-direction: column;
+    min-height: 0;
     background: var(--bg-panel);
     border-radius: 16px;
     box-shadow: 0 20px 46px rgba(0, 0, 0, 0.24);
@@ -166,6 +167,19 @@ body {
     gap: 8px;
 }
 
+.summary-card--mission {
+    grid-column: span 2;
+    gap: 8px;
+}
+
+.summary-card--mission .summary-actions {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.summary-card--mission .summary-actions .primary-button {
+    grid-column: auto;
+}
+
 .summary-card--actions {
     gap: 8px;
 }
@@ -236,11 +250,14 @@ body {
     display: flex;
     flex-direction: column;
     padding: 12px 20px 16px;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .tab-content > .tab-panel {
     flex: 1;
     display: none;
+    min-height: 0;
 }
 
 .tab-panel.active {
@@ -336,8 +353,8 @@ button:disabled {
 
 .list-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+    gap: 8px;
     overflow-y: auto;
     padding-right: 4px;
     flex: 1;
@@ -355,17 +372,17 @@ button:disabled {
 .list-card {
     background: var(--bg-card);
     border-radius: 12px;
-    padding: 11px 13px;
+    padding: 9px 11px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 4px;
     position: relative;
 }
 
 .list-card--compact {
-    padding: 9px 12px;
-    gap: 4px;
+    padding: 8px 10px;
+    gap: 3px;
 }
 
 .list-card.locked {

--- a/ui/style.css
+++ b/ui/style.css
@@ -23,8 +23,8 @@ body {
     font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
     background: transparent;
     color: var(--text-primary);
-    font-size: 15px;
-    line-height: 1.5;
+    font-size: 14px;
+    line-height: 1.45;
 }
 
 .hidden {
@@ -39,16 +39,16 @@ body {
     justify-content: center;
     background: var(--bg-overlay);
     backdrop-filter: blur(6px);
-    padding: 2vh 2vw;
+    padding: 1.5vh 1.5vw;
 }
 
 .panel {
-    width: min(1040px, 100%);
-    max-height: 88vh;
+    width: min(900px, 94vw);
+    max-height: 86vh;
     display: flex;
     flex-direction: column;
     background: var(--bg-panel);
-    border-radius: 20px;
+    border-radius: 18px;
     box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
     border: 1px solid rgba(255, 255, 255, 0.04);
     overflow: hidden;
@@ -58,19 +58,19 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    padding: 22px 28px 16px;
+    padding: 18px 24px 14px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
 .panel-titles h1 {
     margin: 0;
-    font-size: 1.45rem;
+    font-size: 1.32rem;
     letter-spacing: 0.01em;
 }
 
 .panel-titles p {
     margin: 6px 0 0;
-    font-size: 0.88rem;
+    font-size: 0.82rem;
     color: var(--text-secondary);
 }
 
@@ -79,9 +79,9 @@ body {
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: var(--text-primary);
     border-radius: 999px;
-    width: 38px;
-    height: 38px;
-    font-size: 1.1rem;
+    width: 34px;
+    height: 34px;
+    font-size: 1rem;
     cursor: pointer;
     transition: all 120ms ease;
 }
@@ -95,17 +95,17 @@ body {
 .summary-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 16px;
-    padding: 0 28px 20px;
+    gap: 12px;
+    padding: 0 24px 18px;
 }
 
 .summary-card {
     background: var(--bg-card);
-    border-radius: 16px;
-    padding: 18px 20px;
+    border-radius: 14px;
+    padding: 16px 18px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
     border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
@@ -117,34 +117,34 @@ body {
 }
 
 .summary-title {
-    font-size: 0.78rem;
+    font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--text-secondary);
 }
 
 .summary-value {
-    font-size: 2.1rem;
+    font-size: 1.82rem;
     font-weight: 600;
     display: flex;
     align-items: baseline;
-    gap: 10px;
+    gap: 6px;
 }
 
 .summary-value span {
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     color: var(--text-secondary);
     font-weight: 400;
 }
 
 .summary-meta {
-    font-size: 0.88rem;
+    font-size: 0.82rem;
     color: var(--text-secondary);
 }
 
 .progress-bar {
     position: relative;
-    height: 8px;
+    height: 6px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.07);
     overflow: hidden;
@@ -156,6 +156,25 @@ body {
     border-radius: inherit;
     background: linear-gradient(90deg, rgba(255, 77, 90, 0.85), rgba(255, 120, 96, 0.85));
     transition: width 160ms ease;
+}
+
+.summary-card--scalpel {
+    gap: 8px;
+}
+
+.summary-actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 8px;
+    margin-top: 2px;
+}
+
+.summary-actions .primary-button {
+    grid-column: 1 / -1;
+}
+
+.summary-actions .secondary-button {
+    justify-content: center;
 }
 
 .tag {
@@ -179,8 +198,8 @@ body {
 .tab-bar {
     display: flex;
     align-items: center;
-    padding: 0 22px;
-    gap: 12px;
+    padding: 0 20px;
+    gap: 10px;
 }
 
 .tab {
@@ -188,8 +207,8 @@ body {
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    font-size: 0.9rem;
-    padding: 12px 6px;
+    font-size: 0.82rem;
+    padding: 10px 4px;
     cursor: pointer;
     border-bottom: 2px solid transparent;
     transition: all 140ms ease;
@@ -207,7 +226,7 @@ body {
 .tab-content {
     flex: 1;
     overflow-y: auto;
-    padding: 22px 28px 26px;
+    padding: 18px 24px 22px;
 }
 
 .tab-panel {
@@ -221,17 +240,17 @@ body {
 .panel-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 18px;
+    gap: 14px;
 }
 
 .card {
     background: var(--bg-card);
-    border-radius: 16px;
-    padding: 20px;
+    border-radius: 14px;
+    padding: 16px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
 }
 
 .card.wide {
@@ -241,20 +260,20 @@ body {
 
 .card h2 {
     margin: 0;
-    font-size: 1rem;
+    font-size: 0.95rem;
 }
 
 .stat-list {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
 }
 
 .stat-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.9rem;
+    font-size: 0.84rem;
     color: var(--text-secondary);
 }
 
@@ -266,9 +285,9 @@ body {
     background: linear-gradient(135deg, rgba(255, 77, 90, 0.92), rgba(255, 110, 104, 0.92));
     border: none;
     color: #fff;
-    border-radius: 14px;
-    padding: 11px 18px;
-    font-size: 0.9rem;
+    border-radius: 12px;
+    padding: 9px 14px;
+    font-size: 0.82rem;
     cursor: pointer;
     transition: transform 120ms ease, box-shadow 120ms ease;
 }
@@ -283,9 +302,9 @@ body {
     background: rgba(255, 255, 255, 0.08);
     border: none;
     color: var(--text-primary);
-    border-radius: 14px;
-    padding: 9px 16px;
-    font-size: 0.85rem;
+    border-radius: 12px;
+    padding: 8px 14px;
+    font-size: 0.8rem;
     cursor: pointer;
     transition: background 120ms ease;
 }
@@ -302,18 +321,18 @@ button:disabled {
 
 .list-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 18px;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 14px;
 }
 
 .list-card {
     background: var(--bg-card);
-    border-radius: 16px;
-    padding: 18px 20px;
+    border-radius: 14px;
+    padding: 16px 18px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
     position: relative;
 }
 
@@ -322,14 +341,14 @@ button:disabled {
 }
 
 .list-title {
-    font-size: 1rem;
+    font-size: 0.95rem;
     margin: 0;
 }
 
 .list-meta,
 .list-description {
     color: var(--text-secondary);
-    font-size: 0.88rem;
+    font-size: 0.8rem;
 }
 
 .list-meta.accent {
@@ -341,29 +360,31 @@ button:disabled {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
+    flex-wrap: wrap;
 }
 
 .button-group {
     display: flex;
     gap: 8px;
+    flex-wrap: wrap;
 }
 
 .requirements {
     display: flex;
     flex-direction: column;
-    gap: 5px;
-    font-size: 0.84rem;
+    gap: 4px;
+    font-size: 0.78rem;
     color: var(--text-secondary);
 }
 
 .empty-placeholder {
     background: rgba(255, 255, 255, 0.04);
-    border-radius: 16px;
-    padding: 28px 22px;
+    border-radius: 14px;
+    padding: 24px 20px;
     text-align: center;
     color: var(--text-secondary);
-    font-size: 0.96rem;
+    font-size: 0.9rem;
 }
 
 @media (max-width: 900px) {

--- a/ui/style.css
+++ b/ui/style.css
@@ -95,7 +95,7 @@ body {
 
 .summary-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
     gap: 8px;
     padding: 0 20px 12px;
 }
@@ -115,6 +115,10 @@ body {
     background: var(--bg-card-alt);
     border: 1px solid rgba(255, 77, 90, 0.35);
     box-shadow: inset 0 0 0 1px rgba(255, 77, 90, 0.14);
+}
+
+.summary-card--wide {
+    grid-column: span 2;
 }
 
 .summary-title {
@@ -182,6 +186,54 @@ body {
 
 .summary-card--actions {
     gap: 8px;
+}
+
+.mission-sections {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-auto-rows: minmax(0, 1fr);
+    gap: 10px;
+    padding: 0 20px 18px;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.mission-section-card {
+    background: var(--bg-card);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.mission-section-header {
+    padding: 12px 14px 6px;
+}
+
+.mission-section-header h2 {
+    margin: 0;
+    font-size: 0.74rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.mission-section-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 0 14px 12px;
+    gap: 6px;
+    min-height: 0;
+}
+
+.mission-section-body .list-grid {
+    flex: 1;
+    min-height: 0;
+    max-height: none;
+    padding-right: 6px;
 }
 
 .summary-actions {

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,0 +1,391 @@
+:root {
+    --accent: #ff4d5a;
+    --accent-soft: rgba(255, 77, 90, 0.14);
+    --bg-overlay: rgba(14, 22, 30, 0.55);
+    --bg-panel: rgba(18, 26, 35, 0.88);
+    --bg-card: rgba(28, 36, 46, 0.88);
+    --bg-card-alt: rgba(33, 42, 54, 0.94);
+    --text-primary: #f2f6f8;
+    --text-secondary: #9aa7b7;
+    --success: #5bdba7;
+    --warning: #ffb24d;
+}
+
+* {
+    box-sizing: border-box;
+    user-select: none;
+    -webkit-font-smoothing: antialiased;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
+    background: transparent;
+    color: var(--text-primary);
+}
+
+.hidden {
+    display: none;
+}
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-overlay);
+    backdrop-filter: blur(6px);
+    padding: 3vh 3vw;
+}
+
+.panel {
+    width: min(960px, 100%);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-panel);
+    border-radius: 20px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    overflow: hidden;
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 28px 32px 18px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.panel-titles h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    letter-spacing: 0.01em;
+}
+
+.panel-titles p {
+    margin: 6px 0 0;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.ghost-button {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--text-primary);
+    border-radius: 999px;
+    width: 38px;
+    height: 38px;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: all 120ms ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 18px;
+    padding: 0 32px 24px;
+}
+
+.summary-card {
+    background: var(--bg-card);
+    border-radius: 16px;
+    padding: 20px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.summary-card.rep {
+    grid-column: span 2;
+    background: var(--bg-card-alt);
+    border: 1px solid rgba(255, 77, 90, 0.35);
+    box-shadow: inset 0 0 0 1px rgba(255, 77, 90, 0.16);
+}
+
+.summary-title {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-secondary);
+}
+
+.summary-value {
+    font-size: 2.4rem;
+    font-weight: 600;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.summary-value span {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    font-weight: 400;
+}
+
+.summary-meta {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.progress-bar {
+    position: relative;
+    height: 9px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.07);
+    overflow: hidden;
+}
+
+.progress-bar span {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(255, 77, 90, 0.85), rgba(255, 120, 96, 0.85));
+    transition: width 160ms ease;
+}
+
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-secondary);
+}
+
+.tag.accent {
+    background: var(--accent-soft);
+    color: var(--accent);
+}
+
+.tab-bar {
+    display: flex;
+    align-items: center;
+    padding: 0 24px;
+    gap: 12px;
+}
+
+.tab {
+    flex: 1;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    padding: 14px 8px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: all 140ms ease;
+}
+
+.tab.active {
+    color: var(--text-primary);
+    border-bottom-color: var(--accent);
+}
+
+.tab:hover {
+    color: var(--text-primary);
+}
+
+.tab-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px 32px 32px;
+}
+
+.tab-panel {
+    display: none;
+}
+
+.tab-panel.active {
+    display: block;
+}
+
+.panel-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+}
+
+.card {
+    background: var(--bg-card);
+    border-radius: 16px;
+    padding: 22px;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.card.wide {
+    grid-column: span 2;
+    background: var(--bg-card-alt);
+}
+
+.card h2 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.stat-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.stat-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.stat-row strong {
+    color: var(--text-primary);
+}
+
+.primary-button {
+    background: linear-gradient(135deg, rgba(255, 77, 90, 0.92), rgba(255, 110, 104, 0.92));
+    border: none;
+    color: #fff;
+    border-radius: 14px;
+    padding: 12px 20px;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.primary-button:hover,
+.primary-button:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(255, 77, 90, 0.25);
+}
+
+.secondary-button {
+    background: rgba(255, 255, 255, 0.08);
+    border: none;
+    color: var(--text-primary);
+    border-radius: 14px;
+    padding: 10px 18px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 120ms ease;
+}
+
+.secondary-button:hover,
+.secondary-button:focus {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.list-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 18px;
+}
+
+.list-card {
+    background: var(--bg-card);
+    border-radius: 16px;
+    padding: 20px 22px;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    position: relative;
+}
+
+.list-card.locked {
+    opacity: 0.55;
+}
+
+.list-title {
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+.list-meta,
+.list-description {
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+}
+
+.list-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.button-group {
+    display: flex;
+    gap: 8px;
+}
+
+.requirements {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.88rem;
+    color: var(--text-secondary);
+}
+
+.empty-placeholder {
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 16px;
+    padding: 28px 22px;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.96rem;
+}
+
+@media (max-width: 900px) {
+    .summary-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .summary-card.rep {
+        grid-column: span 2;
+    }
+    .panel-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .panel {
+        border-radius: 0;
+        max-height: 100vh;
+    }
+    .overlay {
+        padding: 0;
+    }
+    .summary-grid {
+        grid-template-columns: 1fr;
+    }
+    .tab-bar {
+        flex-wrap: wrap;
+    }
+    .tab {
+        flex: none;
+    }
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -158,7 +158,15 @@ body {
     transition: width 160ms ease;
 }
 
+.progress-bar--thin {
+    height: 4px;
+}
+
 .summary-card--scalpel {
+    gap: 8px;
+}
+
+.summary-card--actions {
     gap: 8px;
 }
 
@@ -336,6 +344,14 @@ button:disabled {
     align-content: flex-start;
 }
 
+#mission-progress-content.list-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+#mission-contracts-content.list-grid {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
 .list-card {
     background: var(--bg-card);
     border-radius: 12px;
@@ -413,6 +429,29 @@ button:disabled {
     gap: 3px;
     font-size: 0.75rem;
     color: var(--text-secondary);
+}
+
+.requirements--progress {
+    gap: 6px;
+}
+
+.requirement-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.requirement-row-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+}
+
+.requirement-row-header strong {
+    color: var(--text-primary);
+    font-weight: 600;
 }
 
 .empty-placeholder {

--- a/ui/style.css
+++ b/ui/style.css
@@ -23,7 +23,7 @@ body {
     font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
     background: transparent;
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: 13px;
     line-height: 1.45;
 }
 
@@ -42,7 +42,8 @@ body {
 }
 
 .panel {
-    width: min(780px, 92vw);
+    width: min(720px, 90vw);
+    height: clamp(600px, 76vh, 760px);
     max-height: 82vh;
     display: flex;
     flex-direction: column;
@@ -94,17 +95,17 @@ body {
 .summary-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 10px;
-    padding: 0 20px 14px;
+    gap: 8px;
+    padding: 0 20px 12px;
 }
 
 .summary-card {
     background: var(--bg-card);
     border-radius: 12px;
-    padding: 14px 16px;
+    padding: 12px 14px;
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 4px;
     border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
@@ -123,7 +124,7 @@ body {
 }
 
 .summary-value {
-    font-size: 1.6rem;
+    font-size: 1.45rem;
     font-weight: 600;
     display: flex;
     align-items: baseline;
@@ -181,8 +182,8 @@ body {
     align-items: center;
     gap: 5px;
     border-radius: 999px;
-    padding: 3px 9px;
-    font-size: 0.72rem;
+    padding: 2px 8px;
+    font-size: 0.68rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     background: rgba(255, 255, 255, 0.08);
@@ -198,7 +199,7 @@ body {
     display: flex;
     align-items: center;
     padding: 0 18px;
-    gap: 8px;
+    gap: 6px;
 }
 
 .tab {
@@ -224,32 +225,38 @@ body {
 
 .tab-content {
     flex: 1;
-    overflow-y: auto;
-    padding: 16px 20px 18px;
+    display: flex;
+    flex-direction: column;
+    padding: 12px 20px 16px;
 }
 
-.tab-panel {
+.tab-content > .tab-panel {
+    flex: 1;
     display: none;
+    overflow: hidden;
 }
 
 .tab-panel.active {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    overflow: hidden;
 }
 
 .panel-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
+    gap: 10px;
 }
 
 .card {
     background: var(--bg-card);
     border-radius: 12px;
-    padding: 14px;
+    padding: 12px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 }
 
 .card.wide {
@@ -259,20 +266,21 @@ body {
 
 .card h2 {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.86rem;
+    letter-spacing: 0.01em;
 }
 
 .stat-list {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
 }
 
 .stat-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     color: var(--text-secondary);
 }
 
@@ -285,8 +293,8 @@ body {
     border: none;
     color: #fff;
     border-radius: 10px;
-    padding: 8px 12px;
-    font-size: 0.78rem;
+    padding: 7px 12px;
+    font-size: 0.74rem;
     cursor: pointer;
     transition: transform 120ms ease, box-shadow 120ms ease;
 }
@@ -302,8 +310,8 @@ body {
     border: none;
     color: var(--text-primary);
     border-radius: 10px;
-    padding: 7px 12px;
-    font-size: 0.76rem;
+    padding: 6px 11px;
+    font-size: 0.72rem;
     cursor: pointer;
     transition: background 120ms ease;
 }
@@ -320,19 +328,28 @@ button:disabled {
 
 .list-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 10px;
+    overflow-y: auto;
+    padding-right: 4px;
+    flex: 1;
+    align-content: flex-start;
 }
 
 .list-card {
     background: var(--bg-card);
     border-radius: 12px;
-    padding: 12px 14px;
+    padding: 11px 13px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 5px;
     position: relative;
+}
+
+.list-card--compact {
+    padding: 9px 12px;
+    gap: 4px;
 }
 
 .list-card.locked {
@@ -340,14 +357,18 @@ button:disabled {
 }
 
 .list-title {
-    font-size: 0.9rem;
+    font-size: 0.86rem;
     margin: 0;
 }
 
 .list-meta,
 .list-description {
     color: var(--text-secondary);
-    font-size: 0.76rem;
+    font-size: 0.74rem;
+}
+
+.list-meta.notice {
+    color: var(--accent);
 }
 
 .list-meta.accent {
@@ -361,6 +382,23 @@ button:disabled {
     align-items: center;
     gap: 6px;
     flex-wrap: wrap;
+}
+
+.list-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 6px;
+}
+
+.list-header .list-title {
+    font-size: 0.82rem;
+}
+
+.list-price {
+    font-size: 0.78rem;
+    color: var(--accent);
+    font-weight: 600;
 }
 
 .button-group {

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,10 +1,10 @@
 :root {
     --accent: #ff4d5a;
     --accent-soft: rgba(255, 77, 90, 0.14);
-    --bg-overlay: rgba(14, 22, 30, 0.55);
+    --bg-overlay: transparent;
     --bg-panel: rgba(18, 26, 35, 0.88);
-    --bg-card: rgba(28, 36, 46, 0.88);
-    --bg-card-alt: rgba(33, 42, 54, 0.94);
+    --bg-card: rgba(28, 36, 46, 0.86);
+    --bg-card-alt: rgba(33, 42, 54, 0.9);
     --text-primary: #f2f6f8;
     --text-secondary: #9aa7b7;
     --success: #5bdba7;
@@ -38,18 +38,17 @@ body {
     align-items: center;
     justify-content: center;
     background: var(--bg-overlay);
-    backdrop-filter: blur(6px);
     padding: 1.5vh 1.5vw;
 }
 
 .panel {
-    width: min(900px, 94vw);
-    max-height: 86vh;
+    width: min(780px, 92vw);
+    max-height: 82vh;
     display: flex;
     flex-direction: column;
     background: var(--bg-panel);
-    border-radius: 18px;
-    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.25);
+    border-radius: 16px;
+    box-shadow: 0 20px 46px rgba(0, 0, 0, 0.24);
     border: 1px solid rgba(255, 255, 255, 0.04);
     overflow: hidden;
 }
@@ -58,19 +57,19 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    padding: 18px 24px 14px;
+    padding: 16px 20px 12px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
 .panel-titles h1 {
     margin: 0;
-    font-size: 1.32rem;
+    font-size: 1.2rem;
     letter-spacing: 0.01em;
 }
 
 .panel-titles p {
-    margin: 6px 0 0;
-    font-size: 0.82rem;
+    margin: 4px 0 0;
+    font-size: 0.78rem;
     color: var(--text-secondary);
 }
 
@@ -79,9 +78,9 @@ body {
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: var(--text-primary);
     border-radius: 999px;
-    width: 34px;
-    height: 34px;
-    font-size: 1rem;
+    width: 32px;
+    height: 32px;
+    font-size: 0.95rem;
     cursor: pointer;
     transition: all 120ms ease;
 }
@@ -95,17 +94,17 @@ body {
 .summary-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 12px;
-    padding: 0 24px 18px;
+    gap: 10px;
+    padding: 0 20px 14px;
 }
 
 .summary-card {
     background: var(--bg-card);
-    border-radius: 14px;
-    padding: 16px 18px;
+    border-radius: 12px;
+    padding: 14px 16px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 5px;
     border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
@@ -113,38 +112,38 @@ body {
     grid-column: span 2;
     background: var(--bg-card-alt);
     border: 1px solid rgba(255, 77, 90, 0.35);
-    box-shadow: inset 0 0 0 1px rgba(255, 77, 90, 0.16);
+    box-shadow: inset 0 0 0 1px rgba(255, 77, 90, 0.14);
 }
 
 .summary-title {
-    font-size: 0.72rem;
+    font-size: 0.68rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--text-secondary);
 }
 
 .summary-value {
-    font-size: 1.82rem;
+    font-size: 1.6rem;
     font-weight: 600;
     display: flex;
     align-items: baseline;
-    gap: 6px;
+    gap: 4px;
 }
 
 .summary-value span {
-    font-size: 0.88rem;
+    font-size: 0.82rem;
     color: var(--text-secondary);
     font-weight: 400;
 }
 
 .summary-meta {
-    font-size: 0.82rem;
+    font-size: 0.78rem;
     color: var(--text-secondary);
 }
 
 .progress-bar {
     position: relative;
-    height: 6px;
+    height: 5px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.07);
     overflow: hidden;
@@ -164,9 +163,9 @@ body {
 
 .summary-actions {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 8px;
-    margin-top: 2px;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 6px;
+    margin-top: 4px;
 }
 
 .summary-actions .primary-button {
@@ -180,10 +179,10 @@ body {
 .tag {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 5px;
     border-radius: 999px;
-    padding: 4px 10px;
-    font-size: 0.75rem;
+    padding: 3px 9px;
+    font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     background: rgba(255, 255, 255, 0.08);
@@ -198,8 +197,8 @@ body {
 .tab-bar {
     display: flex;
     align-items: center;
-    padding: 0 20px;
-    gap: 10px;
+    padding: 0 18px;
+    gap: 8px;
 }
 
 .tab {
@@ -207,8 +206,8 @@ body {
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    font-size: 0.82rem;
-    padding: 10px 4px;
+    font-size: 0.78rem;
+    padding: 8px 2px;
     cursor: pointer;
     border-bottom: 2px solid transparent;
     transition: all 140ms ease;
@@ -226,7 +225,7 @@ body {
 .tab-content {
     flex: 1;
     overflow-y: auto;
-    padding: 18px 24px 22px;
+    padding: 16px 20px 18px;
 }
 
 .tab-panel {
@@ -240,17 +239,17 @@ body {
 .panel-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 14px;
+    gap: 12px;
 }
 
 .card {
     background: var(--bg-card);
-    border-radius: 14px;
-    padding: 16px;
+    border-radius: 12px;
+    padding: 14px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
 }
 
 .card.wide {
@@ -260,20 +259,20 @@ body {
 
 .card h2 {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
 }
 
 .stat-list {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 }
 
 .stat-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.84rem;
+    font-size: 0.8rem;
     color: var(--text-secondary);
 }
 
@@ -285,9 +284,9 @@ body {
     background: linear-gradient(135deg, rgba(255, 77, 90, 0.92), rgba(255, 110, 104, 0.92));
     border: none;
     color: #fff;
-    border-radius: 12px;
-    padding: 9px 14px;
-    font-size: 0.82rem;
+    border-radius: 10px;
+    padding: 8px 12px;
+    font-size: 0.78rem;
     cursor: pointer;
     transition: transform 120ms ease, box-shadow 120ms ease;
 }
@@ -302,9 +301,9 @@ body {
     background: rgba(255, 255, 255, 0.08);
     border: none;
     color: var(--text-primary);
-    border-radius: 12px;
-    padding: 8px 14px;
-    font-size: 0.8rem;
+    border-radius: 10px;
+    padding: 7px 12px;
+    font-size: 0.76rem;
     cursor: pointer;
     transition: background 120ms ease;
 }
@@ -321,18 +320,18 @@ button:disabled {
 
 .list-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 14px;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 12px;
 }
 
 .list-card {
     background: var(--bg-card);
-    border-radius: 14px;
-    padding: 16px 18px;
+    border-radius: 12px;
+    padding: 12px 14px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
     position: relative;
 }
 
@@ -341,14 +340,14 @@ button:disabled {
 }
 
 .list-title {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     margin: 0;
 }
 
 .list-meta,
 .list-description {
     color: var(--text-secondary);
-    font-size: 0.8rem;
+    font-size: 0.76rem;
 }
 
 .list-meta.accent {
@@ -360,7 +359,7 @@ button:disabled {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
     flex-wrap: wrap;
 }
 
@@ -373,18 +372,18 @@ button:disabled {
 .requirements {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    font-size: 0.78rem;
+    gap: 3px;
+    font-size: 0.75rem;
     color: var(--text-secondary);
 }
 
 .empty-placeholder {
     background: rgba(255, 255, 255, 0.04);
-    border-radius: 14px;
-    padding: 24px 20px;
+    border-radius: 12px;
+    padding: 20px 18px;
     text-align: center;
     color: var(--text-secondary);
-    font-size: 0.9rem;
+    font-size: 0.86rem;
 }
 
 @media (max-width: 900px) {

--- a/ui/style.css
+++ b/ui/style.css
@@ -23,6 +23,8 @@ body {
     font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
     background: transparent;
     color: var(--text-primary);
+    font-size: 15px;
+    line-height: 1.5;
 }
 
 .hidden {
@@ -37,12 +39,12 @@ body {
     justify-content: center;
     background: var(--bg-overlay);
     backdrop-filter: blur(6px);
-    padding: 3vh 3vw;
+    padding: 2vh 2vw;
 }
 
 .panel {
-    width: min(960px, 100%);
-    max-height: 90vh;
+    width: min(1040px, 100%);
+    max-height: 88vh;
     display: flex;
     flex-direction: column;
     background: var(--bg-panel);
@@ -56,19 +58,19 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    padding: 28px 32px 18px;
+    padding: 22px 28px 16px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
 .panel-titles h1 {
     margin: 0;
-    font-size: 1.6rem;
+    font-size: 1.45rem;
     letter-spacing: 0.01em;
 }
 
 .panel-titles p {
     margin: 6px 0 0;
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     color: var(--text-secondary);
 }
 
@@ -93,14 +95,14 @@ body {
 .summary-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 18px;
-    padding: 0 32px 24px;
+    gap: 16px;
+    padding: 0 28px 20px;
 }
 
 .summary-card {
     background: var(--bg-card);
     border-radius: 16px;
-    padding: 20px 22px;
+    padding: 18px 20px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -115,34 +117,34 @@ body {
 }
 
 .summary-title {
-    font-size: 0.85rem;
+    font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--text-secondary);
 }
 
 .summary-value {
-    font-size: 2.4rem;
+    font-size: 2.1rem;
     font-weight: 600;
     display: flex;
     align-items: baseline;
-    gap: 12px;
+    gap: 10px;
 }
 
 .summary-value span {
-    font-size: 1rem;
+    font-size: 0.95rem;
     color: var(--text-secondary);
     font-weight: 400;
 }
 
 .summary-meta {
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     color: var(--text-secondary);
 }
 
 .progress-bar {
     position: relative;
-    height: 9px;
+    height: 8px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.07);
     overflow: hidden;
@@ -177,7 +179,7 @@ body {
 .tab-bar {
     display: flex;
     align-items: center;
-    padding: 0 24px;
+    padding: 0 22px;
     gap: 12px;
 }
 
@@ -186,8 +188,8 @@ body {
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    font-size: 0.95rem;
-    padding: 14px 8px;
+    font-size: 0.9rem;
+    padding: 12px 6px;
     cursor: pointer;
     border-bottom: 2px solid transparent;
     transition: all 140ms ease;
@@ -205,7 +207,7 @@ body {
 .tab-content {
     flex: 1;
     overflow-y: auto;
-    padding: 24px 32px 32px;
+    padding: 22px 28px 26px;
 }
 
 .tab-panel {
@@ -225,11 +227,11 @@ body {
 .card {
     background: var(--bg-card);
     border-radius: 16px;
-    padding: 22px;
+    padding: 20px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 12px;
 }
 
 .card.wide {
@@ -239,7 +241,7 @@ body {
 
 .card h2 {
     margin: 0;
-    font-size: 1.05rem;
+    font-size: 1rem;
 }
 
 .stat-list {
@@ -252,7 +254,7 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     color: var(--text-secondary);
 }
 
@@ -265,8 +267,8 @@ body {
     border: none;
     color: #fff;
     border-radius: 14px;
-    padding: 12px 20px;
-    font-size: 0.95rem;
+    padding: 11px 18px;
+    font-size: 0.9rem;
     cursor: pointer;
     transition: transform 120ms ease, box-shadow 120ms ease;
 }
@@ -282,8 +284,8 @@ body {
     border: none;
     color: var(--text-primary);
     border-radius: 14px;
-    padding: 10px 18px;
-    font-size: 0.9rem;
+    padding: 9px 16px;
+    font-size: 0.85rem;
     cursor: pointer;
     transition: background 120ms ease;
 }
@@ -307,11 +309,11 @@ button:disabled {
 .list-card {
     background: var(--bg-card);
     border-radius: 16px;
-    padding: 20px 22px;
+    padding: 18px 20px;
     border: 1px solid rgba(255, 255, 255, 0.04);
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     position: relative;
 }
 
@@ -320,14 +322,19 @@ button:disabled {
 }
 
 .list-title {
-    font-size: 1.05rem;
+    font-size: 1rem;
     margin: 0;
 }
 
 .list-meta,
 .list-description {
     color: var(--text-secondary);
-    font-size: 0.92rem;
+    font-size: 0.88rem;
+}
+
+.list-meta.accent {
+    color: var(--accent);
+    font-weight: 600;
 }
 
 .list-footer {
@@ -345,8 +352,8 @@ button:disabled {
 .requirements {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    font-size: 0.88rem;
+    gap: 5px;
+    font-size: 0.84rem;
     color: var(--text-secondary);
 }
 


### PR DESCRIPTION
## Summary
- replace the ox_lib context tree with an Outlaw-styled dealer NUI that highlights reputation, deliveries, rares, upgrades, and quick actions without a black fullscreen
- extend the dealer payload to expose scalpel variant and kit offers required by the new interface
- wire the client to the NUI callbacks for selling, buying, and upgrading while registering the UI assets in the fxmanifest

## Testing
- luac -p client/main.lua *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e285b480788328a82aae688994416c